### PR TITLE
Specify Ubuntu 14.04 in Dockerfile to ensure successful build

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,4 +16,5 @@
 Anders Hasselqvist <anders.hasselqvist@gmail.com>
 Google Inc. <*@google.com>
 Leandro Moreira <leandro.ribeiro.moreira@gmail.com>
+Philo Inc. <*@philo.com>
 The Chromium Authors <*@chromium.org>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -24,6 +24,7 @@
 
 Anders Hasselqvist <anders.hasselqvist@gmail.com>
 Bei Li <beil@google.com>
+Gabe Kopley <gabe@philo.com>
 Jacob Trimble <modmaker@google.com>
 Joey Parrish <joeyparrish@google.com>
 Kongqun Yang <kqyang@google.com>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:14.04
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
With more recent Ubuntu/Debian, I get this build error when running `ninja -C out/Debug`:

```
../../packager/media/formats/webm/webm_cluster_parser_unittest.cc:603:21: error: default initialization of an object of const type 'const BufferQueue' (aka 'const deque<scoped_refptr<shaka::media::MediaSample> >') without a user-provided default constructor
  const BufferQueue no_text_buffers;
                    ^
                                   {}
1 error generated.
[1238/1302] CXX obj/hls/base/hls_unittest.simple_hls_notifier_unittest.o
ninja: build stopped: subcommand failed.
```

Since CI (Travis) is running Ubuntu 12.04, it seems like a safe bet for the development/test Dockerfile.

I'm working on the corporate CLA now...

