### PR TITLE
Support $DecodeTime$ as filename template variable, work-in-progress

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -157,7 +157,7 @@ muxer_options.output_file_name = …;
 
 // Specify output segment name pattern for generated segments. It can
 // furthermore be configured by using a subset of the SegmentTemplate
-// identifiers: $RepresentationID$, $Number$, $Bandwidth$ and $Time$.
+// identifiers: $RepresentationID$, $Number$, $Bandwidth$, $Time$ and $DecodeTime$.
 // Optional.
 muxer_options.segment_template = …;
 

--- a/packager/media/base/muxer_util.h
+++ b/packager/media/base/muxer_util.h
@@ -36,6 +36,7 @@ bool ValidateSegmentTemplate(const std::string& segment_template);
 /// @return The segment name with identifier substituted.
 std::string GetSegmentName(const std::string& segment_template,
                            uint64_t segment_start_time,
+                           uint64_t segment_start_decode_time,
                            uint32_t segment_index,
                            uint32_t bandwidth);
 

--- a/packager/media/base/muxer_util_unittest.cc
+++ b/packager/media/base/muxer_util_unittest.cc
@@ -16,6 +16,7 @@ TEST(MuxerUtilTest, ValidateSegmentTemplate) {
 
   EXPECT_TRUE(ValidateSegmentTemplate("$Number$"));
   EXPECT_TRUE(ValidateSegmentTemplate("$Time$"));
+  EXPECT_TRUE(ValidateSegmentTemplate("$DecodeTime$"));
   EXPECT_TRUE(ValidateSegmentTemplate("$Time$$Time$"));
   EXPECT_TRUE(ValidateSegmentTemplate("foo$Time$goo"));
   EXPECT_TRUE(ValidateSegmentTemplate("$Number$_$Number$"));
@@ -30,7 +31,7 @@ TEST(MuxerUtilTest, ValidateSegmentTemplate) {
   EXPECT_TRUE(ValidateSegmentTemplate("foo$Time$$$"));
   EXPECT_TRUE(ValidateSegmentTemplate("$$$Time$$$"));
 
-  // Missing $Number$ / $Time$.
+  // Missing $Number$ / $Time$ / $DecodeTime$.
   EXPECT_FALSE(ValidateSegmentTemplate("$$"));
   EXPECT_FALSE(ValidateSegmentTemplate("foo$$goo"));
 
@@ -62,15 +63,18 @@ TEST(MuxerUtilTest, ValidateSegmentTemplateWithFormatTag) {
 
 TEST(MuxerUtilTest, GetSegmentName) {
   const uint64_t kSegmentStartTime = 180180;
+  const uint64_t kSegmentStartDecodeTime = 180173;
   const uint32_t kSegmentIndex = 11;
   const uint32_t kBandwidth = 1234;
   EXPECT_EQ("12", GetSegmentName("$Number$",
+                                 kSegmentStartTime,
                                  kSegmentStartTime,
                                  kSegmentIndex,
                                  kBandwidth));
   EXPECT_EQ("012",
             GetSegmentName("$Number%03d$",
                            kSegmentStartTime,
+                           kSegmentStartDecodeTime,
                            kSegmentIndex,
                            kBandwidth));
   EXPECT_EQ(
@@ -78,17 +82,26 @@ TEST(MuxerUtilTest, GetSegmentName) {
       GetSegmentName(
           "$Number%01d$$$foo$$$Number%05d$",
           kSegmentStartTime,
+          kSegmentStartDecodeTime,
           kSegmentIndex,
           kBandwidth));
 
   EXPECT_EQ("180180",
             GetSegmentName("$Time$",
                            kSegmentStartTime,
+                           kSegmentStartDecodeTime,
+                           kSegmentIndex,
+                           kBandwidth));
+  EXPECT_EQ("180173",
+            GetSegmentName("$DecodeTime$",
+                           kSegmentStartTime,
+                           kSegmentStartDecodeTime,
                            kSegmentIndex,
                            kBandwidth));
   EXPECT_EQ("foo$_$18018000180180.m4s",
             GetSegmentName("foo$$_$$$Time%01d$$Time%08d$.m4s",
                            kSegmentStartTime,
+                           kSegmentStartDecodeTime,
                            kSegmentIndex,
                            kBandwidth));
 
@@ -96,11 +109,13 @@ TEST(MuxerUtilTest, GetSegmentName) {
   EXPECT_EQ("12-1234",
             GetSegmentName("$Number$-$Bandwidth$",
                            kSegmentStartTime,
+                           kSegmentStartDecodeTime,
                            kSegmentIndex,
                            kBandwidth));
   EXPECT_EQ("012-001234",
             GetSegmentName("$Number%03d$-$Bandwidth%06d$",
                            kSegmentStartTime,
+                           kSegmentStartDecodeTime,
                            kSegmentIndex,
                            kBandwidth));
 
@@ -108,47 +123,56 @@ TEST(MuxerUtilTest, GetSegmentName) {
   EXPECT_EQ("12",
             GetSegmentName("$Number%00d$",
                            kSegmentStartTime,
+                           kSegmentStartDecodeTime,
                            kSegmentIndex,
                            kBandwidth));
   EXPECT_EQ("00012",
             GetSegmentName("$Number%005d$",
                            kSegmentStartTime,
+                           kSegmentStartDecodeTime,
                            kSegmentIndex,
                            kBandwidth));
 }
 
 TEST(MuxerUtilTest, GetSegmentNameWithIndexZero) {
   const uint64_t kSegmentStartTime = 0;
+  const uint64_t kSegmentStartDecodeTime = 0;
   const uint32_t kSegmentIndex = 0;
   const uint32_t kBandwidth = 0;
   EXPECT_EQ("1", GetSegmentName("$Number$",
                                 kSegmentStartTime,
+                                kSegmentStartDecodeTime,
                                 kSegmentIndex,
                                 kBandwidth));
   EXPECT_EQ("001",
             GetSegmentName("$Number%03d$",
                            kSegmentStartTime,
+                           kSegmentStartDecodeTime,
                            kSegmentIndex,
                            kBandwidth));
 
   EXPECT_EQ("0", GetSegmentName("$Time$",
                                 kSegmentStartTime,
+                                kSegmentStartDecodeTime,
                                 kSegmentIndex,
                                 kBandwidth));
   EXPECT_EQ("00000000.m4s",
             GetSegmentName("$Time%08d$.m4s",
                            kSegmentStartTime,
+                           kSegmentStartDecodeTime,
                            kSegmentIndex,
                            kBandwidth));
 }
 
 TEST(MuxerUtilTest, GetSegmentNameLargeTime) {
   const uint64_t kSegmentStartTime = 1601599839840ULL;
+  const uint64_t kSegmentStartDecodeTime = 1337;
   const uint32_t kSegmentIndex = 8888888;
   const uint32_t kBandwidth = 444444;
   EXPECT_EQ("1601599839840",
             GetSegmentName("$Time$",
                            kSegmentStartTime,
+                           kSegmentStartDecodeTime,
                            kSegmentIndex,
                            kBandwidth));
 }

--- a/packager/media/formats/mp2t/ts_segmenter.cc
+++ b/packager/media/formats/mp2t/ts_segmenter.cc
@@ -116,7 +116,7 @@ Status TsSegmenter::OpenNewSegmentIfClosed(uint32_t next_pts) {
   if (ts_writer_file_opened_)
     return Status::OK;
   const std::string segment_name =
-      GetSegmentName(muxer_options_.segment_template, next_pts,
+      GetSegmentName(muxer_options_.segment_template, next_pts, next_pts,
                      segment_number_++, muxer_options_.bandwidth);
   if (!ts_writer_->NewSegment(segment_name))
     return Status(error::MUXER_FAILURE, "Failed to initilize TsPacketWriter.");

--- a/packager/media/formats/mp4/multi_segment_segmenter.cc
+++ b/packager/media/formats/mp4/multi_segment_segmenter.cc
@@ -150,6 +150,7 @@ Status MultiSegmentSegmenter::WriteSegment() {
   } else {
     file_name = GetSegmentName(options().segment_template,
                                sidx()->earliest_presentation_time,
+                               moof()->tracks[0].decode_time.decode_time,
                                num_segments_++, options().bandwidth);
     file = File::Open(file_name.c_str(), "w");
     if (file == NULL) {

--- a/packager/media/formats/mp4/segmenter.h
+++ b/packager/media/formats/mp4/segmenter.h
@@ -111,6 +111,7 @@ class Segmenter {
   Movie* moov() { return moov_.get(); }
   BufferWriter* fragment_buffer() { return fragment_buffer_.get(); }
   SegmentIndex* sidx() { return sidx_.get(); }
+  MovieFragment* moof() { return moof_.get() ; } // NOTE delete me!
   MuxerListener* muxer_listener() { return muxer_listener_; }
   uint64_t progress_target() { return progress_target_; }
 

--- a/packager/media/formats/webm/multi_segment_segmenter.cc
+++ b/packager/media/formats/webm/multi_segment_segmenter.cc
@@ -77,8 +77,8 @@ Status MultiSegmentSegmenter::NewSegment(uint64_t start_timescale) {
 
   // Create a new file for the new segment.
   std::string segment_name =
-      GetSegmentName(options().segment_template, start_timescale, num_segment_,
-                     options().bandwidth);
+      GetSegmentName(options().segment_template, start_timescale,
+                     start_timescale, num_segment_, options().bandwidth);
   writer_.reset(new MkvWriter);
   Status status = writer_->Open(segment_name);
   if (!status.ok())

--- a/packager/media/formats/webm/segmenter_test_base.cc
+++ b/packager/media/formats/webm/segmenter_test_base.cc
@@ -101,7 +101,7 @@ std::string SegmentTestBase::OutputFileName() const {
 }
 
 std::string SegmentTestBase::TemplateFileName(int number) const {
-  return GetSegmentName(segment_template_, 0, number, 0);
+  return GetSegmentName(segment_template_, 0, 0, number, 0);
 }
 
 SegmentTestBase::ClusterParser::ClusterParser() : in_cluster_(false) {}


### PR DESCRIPTION
This not yet merge-able, but is a minimum hack to support my use case of packaging DASH for Chrome when the fragment start PTS and start DTS do not match ( #113 ). I'm working on improving the correctness and design of this patch, but figured I'd share my direction in case you all have early feedback. Thanks!