### PR TITLE
Add a runtime flag to use dts in timeline for mp4 (by @kqyang )

### DIFF
--- a/packager/media/file/file.cc
+++ b/packager/media/file/file.cc
@@ -6,9 +6,9 @@
 
 #include "packager/media/file/file.h"
 
+#include <gflags/gflags.h>
 #include <algorithm>
 
-#include <gflags/gflags.h>
 #include "packager/base/logging.h"
 #include "packager/base/memory/scoped_ptr.h"
 #include "packager/media/file/local_file.h"

--- a/packager/media/formats/mp4/mp4.gyp
+++ b/packager/media/formats/mp4/mp4.gyp
@@ -49,6 +49,7 @@
       ],
       'dependencies': [
         '../../../third_party/boringssl/boringssl.gyp:boringssl',
+        '../../../third_party/gflags/gflags.gyp:gflags',
         '../../base/media_base.gyp:media_base',
         '../../codecs/codecs.gyp:codecs',
         '../../event/media_event.gyp:media_event',


### PR DESCRIPTION
(making this PR because I'm having trouble building locally - curious to see build output from Travis)

This flag is needed to workaround the Chromium bug
https://crbug.com/398130, which uses decoding timestamp
in buffered range.

Change-Id: Ib8f18be7165dd968bdc36c18ce29f694235c0c26