### PR TITLE
Basic PlayReady support / issue 128

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,6 +16,7 @@
 Anders Hasselqvist <anders.hasselqvist@gmail.com>
 Chun-da Chen <capitalm.c@gmail.com>
 Google Inc. <*@google.com>
+Inside Secure <*@insidesecure.com>
 Leandro Moreira <leandro.ribeiro.moreira@gmail.com>
 Philo Inc. <*@philo.com>
 Sergio Ammirata <sergio@ammirata.net>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -33,4 +33,5 @@ Kongqun Yang <kqyang@google.com>
 Leandro Moreira <leandro.ribeiro.moreira@gmail.com>
 Rintaro Kuroiwa <rkuroiwa@google.com>
 Sergio Ammirata <sergio@ammirata.net>
+Simo Bergman <sbergman@insidesecure.com>
 Thomas Inskip <tinskip@google.com>

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -16,6 +16,7 @@
 #include "packager/app/stream_descriptor.h"
 #include "packager/app/vlog_flags.h"
 #include "packager/app/widevine_encryption_flags.h"
+#include "packager/app/playready_encryption_flags.h"
 #include "packager/base/at_exit.h"
 #include "packager/base/command_line.h"
 #include "packager/base/files/file_path.h"
@@ -452,7 +453,9 @@ bool RunPackager(const StreamDescriptorList& stream_descriptors) {
 
   // Create encryption key source if needed.
   std::unique_ptr<KeySource> encryption_key_source;
-  if (FLAGS_enable_widevine_encryption || FLAGS_enable_fixed_key_encryption) {
+  if (FLAGS_enable_widevine_encryption ||
+      FLAGS_enable_fixed_key_encryption ||
+      FLAGS_enable_playready_encryption ) {
     encryption_key_source = CreateEncryptionKeySource();
     if (!encryption_key_source)
       return false;

--- a/packager/app/packager_util.cc
+++ b/packager/app/packager_util.cc
@@ -13,6 +13,7 @@
 #include "packager/app/mpd_flags.h"
 #include "packager/app/muxer_flags.h"
 #include "packager/app/widevine_encryption_flags.h"
+#include "packager/app/playready_encryption_flags.h"
 #include "packager/base/logging.h"
 #include "packager/base/strings/string_number_conversions.h"
 #include "packager/media/base/fixed_key_source.h"
@@ -22,6 +23,7 @@
 #include "packager/media/base/request_signer.h"
 #include "packager/media/base/stream_info.h"
 #include "packager/media/base/widevine_key_source.h"
+#include "packager/media/base/playready_key_source.h"
 #include "packager/media/file/file.h"
 #include "packager/mpd/base/mpd_builder.h"
 
@@ -96,6 +98,11 @@ std::unique_ptr<KeySource> CreateEncryptionKeySource() {
       return std::unique_ptr<KeySource>();
     }
     encryption_key_source = std::move(widevine_key_source);
+  } else if (FLAGS_enable_playready_encryption) {
+      encryption_key_source = PlayReadyKeySource::CreateFromHexStrings(
+          FLAGS_pr_key_id, FLAGS_pr_key, FLAGS_pr_iv,
+          FLAGS_pr_la_url, FLAGS_pr_lui_url,
+          FLAGS_pr_include_empty_license_store);
   } else if (FLAGS_enable_fixed_key_encryption) {
     encryption_key_source = FixedKeySource::CreateFromHexStrings(
         FLAGS_key_id, FLAGS_key, FLAGS_pssh, FLAGS_iv);

--- a/packager/app/playready_encryption_flags.cc
+++ b/packager/app/playready_encryption_flags.cc
@@ -1,0 +1,99 @@
+// Copyright 2016 Inside Secure Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+//
+// Defines command line flags for PlayReady encryption.
+
+#include "packager/app/playready_encryption_flags.h"
+
+#include "packager/app/validate_flag.h"
+#include "packager/base/strings/stringprintf.h"
+
+DEFINE_bool(enable_playready_encryption,
+            false,
+            "Enable encryption with PlayReady. If enabled User should "
+            "provide at least encryption key and encryption key id(--pr_key, "
+            "pr_key_id).");
+DEFINE_string(pr_key_id, "", "Encryption key Key id in hex string format.");
+DEFINE_string(pr_key, "", "Encryption key in hex string format.");
+DEFINE_string(pr_iv,
+              "",
+              "Optional iv in hex string format. If not specified, a random iv will be "
+              "generated. This flag should only be used for testing.");
+DEFINE_string(pr_la_url,
+              "",
+              "Optional license acquisition web service URL.");
+DEFINE_string(pr_lui_url,
+              "",
+              "Optional non-silent license acquisition web page URL.");
+DEFINE_bool(pr_include_empty_license_store,
+            false,
+            "Is an empty license store in included in the PlayReady pssh data."
+            "This option is not recommended, with parameter --mpd_output.");
+
+namespace shaka {
+
+bool ValidatePlayreadyCryptoFlags() {
+  bool success = true;
+
+ 
+  const char playready_crypto_label[] = "--enable_playready_encryption";
+  if (!ValidateFlag(
+          "pr_key_id", FLAGS_pr_key_id, FLAGS_enable_playready_encryption,
+          false, playready_crypto_label)) {
+    success = false;
+  }
+
+  if (FLAGS_pr_key_id.size() != 2 * 16) {
+       PrintError(
+          "--pr_kid should be either 16 bytes (32 hex digits).");
+       success = false;
+  }
+  
+  if (!ValidateFlag(
+          "pr_key", FLAGS_pr_key, FLAGS_enable_playready_encryption,
+          false, playready_crypto_label)) {
+    success = false;
+  }
+  if (!ValidateFlag("pr_iv", FLAGS_pr_iv, FLAGS_enable_playready_encryption, true,
+                    playready_crypto_label)) {
+    success = false;
+  }
+
+  if (!FLAGS_pr_iv.empty()) {
+    if (FLAGS_pr_iv.size() != 8 * 2 && FLAGS_pr_iv.size() != 16 * 2) {
+      PrintError(
+          "--pr_iv should be either 8 bytes (16 hex digits) or 16 bytes (32 hex "
+          "digits).");
+      success = false;
+    }
+  }
+
+  if (!ValidateFlag(
+          "pr_la_url", FLAGS_pr_la_url,
+          FLAGS_enable_playready_encryption,
+          true, playready_crypto_label)) {
+    success = false;
+  }    
+
+  if (!ValidateFlag(
+          "pr_lui_url", FLAGS_pr_lui_url,
+          FLAGS_enable_playready_encryption,
+          true, playready_crypto_label)) {
+    success = false;
+  }    
+
+  if (!FLAGS_enable_playready_encryption &&
+      FLAGS_pr_include_empty_license_store) {
+      PrintError(base::StringPrintf(
+                     "--pr_include_empty_license_store should be specified "
+                     " only if %s", playready_crypto_label));
+      success = false;
+  }
+  
+  return success;
+}
+
+}  // namespace shaka

--- a/packager/app/playready_encryption_flags.h
+++ b/packager/app/playready_encryption_flags.h
@@ -1,0 +1,30 @@
+// Copyright 2016 Inside Secure Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+//
+// Defines command line flags for PlayReady encryption.
+
+#ifndef APP_PLAYREADY_ENCRYPTION_FLAGS_H_
+#define APP_PLAYREADY_ENCRYPTION_FLAGS_H_
+
+#include <gflags/gflags.h>
+
+DECLARE_bool(enable_playready_encryption);
+DECLARE_string(pr_key_id);
+DECLARE_string(pr_key);
+DECLARE_string(pr_iv);
+DECLARE_string(pr_la_url);
+DECLARE_string(pr_lui_url);
+DECLARE_bool(pr_include_empty_license_store);
+
+namespace shaka {
+
+/// Validate playready encryption flags.
+/// @return true on success, false otherwise.
+bool ValidatePlayreadyCryptoFlags();
+
+}  // namespace shaka
+
+#endif  // APP_PLAYREADY_ENCRYPTION_FLAGS_H_

--- a/packager/app/test/packager_test.py
+++ b/packager/app/test/packager_test.py
@@ -434,6 +434,12 @@ class PackagerAppTest(unittest.TestCase):
     self._AssertStreamInfo(self.output[0], 'is_encrypted: true')
     self._AssertStreamInfo(self.output[1], 'is_encrypted: true')
 
+  def testPlayReadyEncryption(self):
+    flags = self._GetFlags(playready_encryption=True)
+    self.packager.Package(self._GetStreams(['audio', 'video']), flags)
+    self._AssertStreamInfo(self.output[0], 'is_encrypted: true')
+    self._AssertStreamInfo(self.output[1], 'is_encrypted: true')
+    
   def _GetStreams(self,
                   stream_descriptors,
                   output_format=None,
@@ -495,6 +501,7 @@ class PackagerAppTest(unittest.TestCase):
                 decryption=False,
                 random_iv=False,
                 widevine_encryption=False,
+                playready_encryption=False,
                 key_rotation=False,
                 live=False,
                 dash_if_iop=False,
@@ -508,6 +515,13 @@ class PackagerAppTest(unittest.TestCase):
       flags += ['--enable_widevine_encryption',
                 '--key_server_url=' + widevine_server_url,
                 '--content_id=3031323334353637', '--signer=widevine_test']
+    elif playready_encryption:
+        pr_key ="000102030405060708090a0b0c0d0e0f"
+        pr_kid ="000102030405060708090a0b0c0d0e0f"
+        flags += ['--enable_playready_encryption',
+                    '--pr_key=' + pr_key,
+                    '--pr_key_id=' + pr_kid,
+                    '--pr_la_url=https://goo.gl/laurl']
     elif encryption:
       flags += ['--enable_fixed_key_encryption',
                 '--key_id=31323334353637383930313233343536',

--- a/packager/media/base/media_base.gyp
+++ b/packager/media/base/media_base.gyp
@@ -72,6 +72,8 @@
         'producer_consumer_queue.h',
         'protection_system_specific_info.cc',
         'protection_system_specific_info.h',
+        'playready_pssh_data.cc',
+        'playready_pssh_data.h',
         'rcheck.h',
         'request_signer.cc',
         'request_signer.h',
@@ -91,6 +93,8 @@
         'video_stream_info.h',
         'widevine_key_source.cc',
         'widevine_key_source.h',
+        'playready_key_source.cc',
+        'playready_key_source.h',
       ],
       'dependencies': [
         'widevine_pssh_data_proto',
@@ -141,6 +145,7 @@
         'test/rsa_test_data.h',   # For rsa_key_unittest
         'test/status_test_util.h',
         'widevine_key_source_unittest.cc',
+        'playready_key_source_unittest.cc',
       ],
       'dependencies': [
         '../../testing/gtest.gyp:gtest',

--- a/packager/media/base/playready_key_source.cc
+++ b/packager/media/base/playready_key_source.cc
@@ -1,0 +1,135 @@
+// Copyright 2016 Inside Secure Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+#include "packager/media/base/playready_key_source.h"
+
+#include <algorithm>
+#include "packager/media/base/playready_pssh_data.h"
+#include "packager/base/logging.h"
+#include "packager/base/strings/string_number_conversions.h"
+#include "packager/base/strings/string_tokenizer.h"
+#include "packager/base/strings/string_util.h"
+
+namespace shaka {
+
+namespace {
+const size_t kPlayReadyKIDSize = 16;
+}
+    
+namespace media {
+
+PlayReadyKeySource::~PlayReadyKeySource() {}
+
+  Status PlayReadyKeySource::FetchKeys(const std::vector<uint8_t>& /*pssh_box*/) {
+  // Do nothing for Playready encryption
+  return Status::OK;
+}
+
+Status PlayReadyKeySource::FetchKeys(
+    const std::vector<std::vector<uint8_t>>& /*key_ids*/) {
+    // Do nothing for Playready encryption
+  return Status::OK;
+}
+
+Status PlayReadyKeySource::FetchKeys(uint32_t /*asset_id*/) {
+    // Do nothing for Playready encryption
+  return Status::OK;
+}
+
+Status PlayReadyKeySource::GetKey(TrackType track_type, EncryptionKey* key) {
+  DCHECK(key);
+  DCHECK(encryption_key_);
+  *key = *encryption_key_;
+  return Status::OK;
+}
+
+Status PlayReadyKeySource::GetKey(const std::vector<uint8_t>& key_id,
+                                  EncryptionKey* key) {
+  DCHECK(key);
+  DCHECK(encryption_key_);
+  if (key_id != encryption_key_->key_id) {
+    return Status(error::NOT_FOUND,
+                  std::string("Key for key ID ") +
+                      base::HexEncode(&key_id[0], key_id.size()) +
+                      " was not found.");
+  }
+  *key = *encryption_key_;
+  return Status::OK;
+}
+
+Status PlayReadyKeySource::GetCryptoPeriodKey(uint32_t /*crypto_period_index*/,
+                                              TrackType /*track_type*/,
+                                              EncryptionKey* key) {
+  // Not supported for PlayReady. Just return the same key always
+  *key = *encryption_key_;
+  return Status::OK;
+}
+
+std::unique_ptr<PlayReadyKeySource> PlayReadyKeySource::CreateFromHexStrings(
+    const std::string& key_id_hex,
+      const std::string& key_hex,
+      const std::string& iv_hex,
+      const std::string& la_url,
+      const std::string& lui_url,
+      bool include_empty_license_store) {
+    
+  std::unique_ptr<EncryptionKey> encryption_key(new EncryptionKey());
+  
+  if (!base::HexStringToBytes(key_id_hex, &encryption_key->key_id)) {
+    LOG(ERROR) << "Cannot parse key_id_hex " << key_id_hex;
+    return std::unique_ptr<PlayReadyKeySource>();
+  } else if (encryption_key->key_id.size() != kPlayReadyKIDSize) {
+    LOG(ERROR) << "Invalid key ID size '" << encryption_key->key_id.size()
+               << "', must be " << kPlayReadyKIDSize << " bytes.";
+    return std::unique_ptr<PlayReadyKeySource>();
+  }
+
+  if (!base::HexStringToBytes(key_hex, &encryption_key->key)) {
+    LOG(ERROR) << "Cannot parse key_hex " << key_hex;
+    return std::unique_ptr<PlayReadyKeySource>();
+  }
+
+  if (!iv_hex.empty()) {
+    if (!base::HexStringToBytes(iv_hex, &encryption_key->iv)) {
+      LOG(ERROR) << "Cannot parse iv_hex " << iv_hex;
+      return std::unique_ptr<PlayReadyKeySource>();
+    }
+  }
+
+  //Construct pssh data
+  ProtectionSystemSpecificInfo info;
+  PlayReadyPsshData psshData;
+  std::vector<uint8_t> psshDataBuffer;
+  
+  if (!psshData.add_key_info(*encryption_key.get())) {
+      //We have already parsed the keyid once. It should be ok and
+      //we should never end up in here.
+      LOG(ERROR) << "Invalid key ID '" << key_id_hex;
+      return std::unique_ptr<PlayReadyKeySource>();  
+  }
+      
+  psshData.set_la_url(la_url);
+  psshData.set_lui_url(lui_url);
+  psshData.set_include_empty_license_store(include_empty_license_store);
+  psshData.serialize_to_vector(psshDataBuffer);
+
+  info.add_key_id(encryption_key->key_id);
+  info.set_system_id(kPlayreadySystemId, arraysize(kPlayreadySystemId));
+  info.set_pssh_box_version(0);
+  info.set_pssh_data(psshDataBuffer);
+  
+  encryption_key->key_system_info.push_back(info);
+
+  return std::unique_ptr<PlayReadyKeySource>(
+      new PlayReadyKeySource(std::move(encryption_key)));
+}
+
+PlayReadyKeySource::PlayReadyKeySource() {}
+PlayReadyKeySource::PlayReadyKeySource(std::unique_ptr<EncryptionKey> key)
+    : encryption_key_(std::move(key)) {}
+
+}  // namespace media
+}  // namespace shaka

--- a/packager/media/base/playready_key_source.h
+++ b/packager/media/base/playready_key_source.h
@@ -1,0 +1,76 @@
+// Copyright 2016 Inside Secure Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+#ifndef MEDIA_BASE_PLAYREADY_SOURCE_H_
+#define MEDIA_BASE_PLAYREADY_SOURCE_H_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "packager/media/base/key_source.h"
+
+namespace shaka {
+namespace media {
+
+// Playready system id.
+// https://goo.gl/kUv2Xd
+const uint8_t kPlayreadySystemId[] = {0x9a, 0x04, 0xf0, 0x79, 0x98, 0x40,
+                                      0x42, 0x86, 0xab, 0x92, 0xe6, 0x5b,
+                                      0xe0, 0x88, 0x5f, 0x95};
+
+/// A key source that uses fixed keys for encryption.
+class PlayReadyKeySource : public KeySource {
+ public:
+  ~PlayReadyKeySource() override;
+
+  /// @name KeySource implementation overrides.
+  /// @{
+  Status FetchKeys(const std::vector<uint8_t>& pssh_box) override;
+  Status FetchKeys(const std::vector<std::vector<uint8_t>>& key_ids) override;
+  Status FetchKeys(uint32_t asset_id) override;
+
+  Status GetKey(TrackType track_type, EncryptionKey* key) override;
+  Status GetKey(const std::vector<uint8_t>& key_id,
+                EncryptionKey* key) override;
+  Status GetCryptoPeriodKey(uint32_t crypto_period_index,
+                            TrackType track_type,
+                            EncryptionKey* key) override;
+  /// @}
+
+  /// Creates a new PlayReadyKeySource from the given hex strings.  Returns null
+  /// if the strings are invalid.
+  /// @param key_id_hex is the key id in hex string.
+  /// @param key_hex is the key in hex string.
+  /// @param pssh_boxes_hex is the pssh_boxes in hex string.
+  /// @param iv_hex is the IV in hex string. If not specified, a randomly
+  ///        generated IV with the default length will be used.
+  /// Note: GetKey on the created key source will always return the same key
+  ///       for all track types.
+  static std::unique_ptr<PlayReadyKeySource> CreateFromHexStrings(
+      const std::string& key_id_hex,
+      const std::string& key_hex,
+      const std::string& iv_hex,
+      const std::string& la_url,
+      const std::string& lui_url,
+      bool include_empty_license_store);
+
+ protected:
+  // Allow default constructor for mock key sources.
+  PlayReadyKeySource();
+
+ private:
+  explicit PlayReadyKeySource(std::unique_ptr<EncryptionKey> key);
+
+  std::unique_ptr<EncryptionKey> encryption_key_;
+
+  DISALLOW_COPY_AND_ASSIGN(PlayReadyKeySource);
+};
+
+}  // namespace media
+}  // namespace shaka
+
+#endif  // MEDIA_BASE_PLAYREADY_SOURCE_H_

--- a/packager/media/base/playready_key_source_unittest.cc
+++ b/packager/media/base/playready_key_source_unittest.cc
@@ -1,0 +1,141 @@
+// Copyright 2016 Inside Secure Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "packager/base/strings/string_number_conversions.h"
+#include "packager/media/base/playready_key_source.h"
+#include "packager/media/base/test/status_test_util.h"
+
+#define EXPECT_HEX_EQ(expected, actual)                         \
+  do {                                                          \
+    std::vector<uint8_t> decoded_;                              \
+    ASSERT_TRUE(base::HexStringToBytes((expected), &decoded_)); \
+    EXPECT_EQ(decoded_, (actual));                              \
+  } while (false)
+
+namespace shaka {
+namespace media {
+
+namespace {
+const char kKeyIdHex[] = "000102030405060708090a0b0c0d0e0f";
+const char kInvalidKeyIdHex[] = "00010203040506070809";
+const char kKeyHex[] = "00100100200300500801302103405500";
+const char kIvHex[] = "0f0e0d0c0b0a09080706050403020100";
+
+const char kLaUrl[] =  "https://goo.gl/laurl";
+const char kLuiUrl[] = "https://goo.gl/luiurl";
+
+const char kPsshBox1Hex[] =
+    "000002c070737368000000009a04f07998404286ab92e65be0885f950000"
+    "02a0a00200000100010096023c00570052004d0048004500410044004500"
+    "5200200078006d006c006e0073003d00220068007400740070003a002f00"
+    "2f0073006300680065006d00610073002e006d006900630072006f007300"
+    "6f00660074002e0063006f006d002f00440052004d002f00320030003000"
+    "37002f00300033002f0050006c0061007900520065006100640079004800"
+    "6500610064006500720022002000760065007200730069006f006e003d00"
+    "220034002e0030002e0030002e00300022003e003c004400410054004100"
+    "3e003c00500052004f00540045004300540049004e0046004f003e003c00"
+    "4b00450059004c0045004e003e00310036003c002f004b00450059004c00"
+    "45004e003e003c0041004c004700490044003e0041004500530043005400"
+    "52003c002f0041004c004700490044003e003c002f00500052004f005400"
+    "45004300540049004e0046004f003e003c004b00490044003e0041004100"
+    "4500430041007700510046004200670063004900430051006f004c004400"
+    "410030004f00440077003d003d003c002f004b00490044003e003c004c00"
+    "41005f00550052004c003e00680074007400700073003a002f002f006700"
+    "6f006f002e0067006c002f006c006100750072006c003c002f004c004100"
+    "5f00550052004c003e003c004c00550049005f00550052004c003e006800"
+    "74007400700073003a002f002f0067006f006f002e0067006c002f006c00"
+    "75006900750072006c003c002f004c00550049005f00550052004c003e00"
+    "3c0043004800450043004b00530055004d003e00720041006a0031004300"
+    "700077006f006200340067003d003c002f0043004800450043004b005300"
+    "55004d003e003c002f0044004100540041003e003c002f00570052004d00"
+    "4800450041004400450052003e00";
+
+const char kPsshBox2Hex[] =
+    "0000022670737368000000009a04f07998404286ab92e65be0885f950000"
+    "02060602000001000100fc013c00570052004d0048004500410044004500"
+    "5200200078006d006c006e0073003d00220068007400740070003a002f00"
+    "2f0073006300680065006d00610073002e006d006900630072006f007300"
+    "6f00660074002e0063006f006d002f00440052004d002f00320030003000"
+    "37002f00300033002f0050006c0061007900520065006100640079004800"
+    "6500610064006500720022002000760065007200730069006f006e003d00"
+    "220034002e0030002e0030002e00300022003e003c004400410054004100"
+    "3e003c00500052004f00540045004300540049004e0046004f003e003c00"
+    "4b00450059004c0045004e003e00310036003c002f004b00450059004c00"
+    "45004e003e003c0041004c004700490044003e0041004500530043005400"
+    "52003c002f0041004c004700490044003e003c002f00500052004f005400"
+    "45004300540049004e0046004f003e003c004b00490044003e0041004100"
+    "4500430041007700510046004200670063004900430051006f004c004400"
+    "410030004f00440077003d003d003c002f004b00490044003e003c004300"
+    "4800450043004b00530055004d003e00720041006a003100430070007700"
+    "6f006200340067003d003c002f0043004800450043004b00530055004d00"
+    "3e003c002f0044004100540041003e003c002f00570052004d0048004500"
+    "41004400450052003e00";
+}
+
+TEST(PlayReadyKeySourceTest, CreateFromHexStrings_Success) {
+     
+  std::unique_ptr<PlayReadyKeySource> key_source =
+      PlayReadyKeySource::CreateFromHexStrings(kKeyIdHex, kKeyHex, kIvHex,
+                                               kLaUrl, kLuiUrl,
+                                               false);
+  ASSERT_NE(nullptr, key_source);
+
+  EncryptionKey key;
+  ASSERT_OK(key_source->GetKey(KeySource::TRACK_TYPE_SD, &key));
+
+  EXPECT_HEX_EQ(kKeyIdHex, key.key_id);
+  EXPECT_HEX_EQ(kKeyHex, key.key);
+  EXPECT_HEX_EQ(kIvHex, key.iv);
+
+  ASSERT_EQ(1u, key.key_system_info.size());
+  EXPECT_HEX_EQ(kPsshBox1Hex, key.key_system_info[0].CreateBox());
+}
+
+
+TEST(PlayReadyKeySourceTest, CreateFromHexStrings_Failure) {
+
+   
+  std::unique_ptr<PlayReadyKeySource> key_source =
+      PlayReadyKeySource::CreateFromHexStrings(kInvalidKeyIdHex, kKeyHex, kIvHex,
+                                               kLaUrl, kLuiUrl, false);
+  EXPECT_EQ(nullptr, key_source);
+
+   //Empty KID
+  key_source = PlayReadyKeySource::CreateFromHexStrings("", kKeyHex, kIvHex,
+                                                        kLaUrl, kLuiUrl,
+                                                        false);
+  EXPECT_EQ(nullptr, key_source);
+
+  //Empty Key
+  key_source = PlayReadyKeySource::CreateFromHexStrings(kKeyIdHex, "", kIvHex,
+                                                        kLaUrl, kLuiUrl, false);
+  EXPECT_EQ(nullptr, key_source);
+  
+}
+
+TEST(PlayReadyKeySourceTest, CreateFromHexStrings_OptionalParameters) {
+  std::unique_ptr<PlayReadyKeySource> key_source =
+      PlayReadyKeySource::CreateFromHexStrings(kKeyIdHex, kKeyHex, kIvHex,
+                                               "", "", false);
+  ASSERT_NE(nullptr, key_source);
+
+  EncryptionKey key;
+  ASSERT_OK(key_source->GetKey(KeySource::TRACK_TYPE_SD, &key));
+
+  EXPECT_HEX_EQ(kKeyIdHex, key.key_id);
+  EXPECT_HEX_EQ(kKeyHex, key.key);
+  EXPECT_HEX_EQ(kIvHex, key.iv);
+
+  ASSERT_EQ(1u, key.key_system_info.size());
+  EXPECT_HEX_EQ(kPsshBox2Hex, key.key_system_info[0].CreateBox());
+
+}
+
+}  // namespace media
+}  // namespace shaka

--- a/packager/media/base/playready_pssh_data.cc
+++ b/packager/media/base/playready_pssh_data.cc
@@ -1,0 +1,246 @@
+// Copyright 2016 Inside Secure Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+#include <codecvt>
+#include <openssl/aes.h>
+
+#include "packager/media/base/playready_pssh_data.h"
+
+#include "packager/base/logging.h"
+#include "packager/base/base64.h"
+#include "packager/base/strings/string_number_conversions.h"
+
+namespace shaka {    
+namespace media {
+
+namespace {
+    
+const char16_t WRMHEADER_START_TAG[] =
+    u"<WRMHEADER " 
+     "xmlns=\"http://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader\" "
+     "version=\"4.0.0.0\">";
+
+const char16_t WRMHEADER_END_TAG[] =
+    u"</WRMHEADER>";
+
+const char16_t DATA_START_TAG[] = u"<DATA>";
+const char16_t DATA_END_TAG[] = u"</DATA>";
+    
+const char16_t PROTECT_INFO_TAG[] =
+    u"<PROTECTINFO><KEYLEN>16</KEYLEN><ALGID>AESCTR</ALGID></PROTECTINFO>";
+
+const char16_t KID_START_TAG[] =
+    u"<KID>";
+
+const char16_t KID_END_TAG[] =
+    u"</KID>";
+
+const char16_t CHECKSUM_START_TAG[] =
+    u"<CHECKSUM>";
+
+const char16_t CHECKSUM_END_TAG[] =
+    u"</CHECKSUM>";
+
+const char16_t LA_URL_START_TAG[] = u"<LA_URL>";
+const char16_t LA_URL_END_TAG[] = u"</LA_URL>";
+
+const char16_t LUI_URL_START_TAG[] = u"<LUI_URL>";
+const char16_t LUI_URL_END_TAG[] = u"</LUI_URL>";
+    
+    
+const uint16_t PR_RIGHT_MGMT_RECORD_TYPE = 0x0001;
+const uint16_t PR_EMBEDDED_LICENSE_STORE_RECORD_TYPE = 0x0003;
+const uint16_t PR_EMBEDDED_LICENSE_STORE_SIZE = 10 * 1024;
+
+const size_t PR_KID_CHECKSUM_LENGTH = 8;
+
+} 
+
+PlayReadyPsshData::PlayReadyPsshData()
+    :include_empty_license_store_(false)
+{
+}
+
+bool PlayReadyPsshData::add_key_info(const EncryptionKey& encryption_key)
+{
+    //In playready KID has to be in GUID format:
+    //(DWORD, WORD, WORD, 8-BYTE array) in little endian.
+    const size_t GUID_LENGTH = sizeof(uint32_t) + sizeof(uint16_t) +
+        sizeof(uint16_t) + 8;
+    
+    if (encryption_key.key_id.size() != GUID_LENGTH) {
+        LOG(ERROR) << "Invalid key id length " << encryption_key.key_id.size()
+                   << ". Expecting " << GUID_LENGTH;
+        return false;
+    }
+
+    const std::string kid(
+        reinterpret_cast<const char*>(encryption_key.key_id.data()),
+        encryption_key.key_id.size());
+    std::string kidChecksum;
+    std::string base64Kid;
+    std::string base64KidChecksum;
+    
+    //base64 encode kid
+    base::Base64Encode(kid, &base64Kid);
+    
+    //Calculate KID checksum
+    if (!PlayReadyPsshData::kid_check_sum(encryption_key.key_id,
+                                          encryption_key.key,
+                                          kidChecksum)) {
+        LOG(ERROR) << "Key id checksum calculation failed.";
+        return false;
+
+    }
+    //base64 encode kid checksum
+    base::Base64Encode(kidChecksum, &base64KidChecksum);
+    
+    //Convert to UTF16
+    std::wstring_convert<std::codecvt_utf8_utf16<char16_t>,char16_t> conversion;
+
+    kid_ = ::std::pair<::std::u16string, ::std::u16string>(
+        conversion.from_bytes(base64Kid), conversion.from_bytes(base64KidChecksum));
+    
+    return true;
+}
+    
+void PlayReadyPsshData::set_la_url(const ::std::string& value)
+{
+    std::wstring_convert<std::codecvt_utf8_utf16<char16_t>,char16_t> conversion;
+    la_url_ = conversion.from_bytes(value);
+}
+
+void PlayReadyPsshData::set_lui_url(const ::std::string& value)
+{
+    std::wstring_convert<std::codecvt_utf8_utf16<char16_t>,char16_t> conversion;
+    lui_url_ = conversion.from_bytes(value);    
+}
+
+void PlayReadyPsshData::set_include_empty_license_store(bool include)
+{
+    include_empty_license_store_ = include;
+}
+    
+void PlayReadyPsshData::serialize_to_vector(::std::vector<uint8_t>& output) const
+{
+    /* PSSH data format is specified in Microsoft Playready Header Object document.
+       This implementation implements Rigths Management Header V4.2.0.0 */
+    
+    //Generate the XML content;
+    ::std::u16string xmlContent = WRMHEADER_START_TAG;
+    xmlContent.append(DATA_START_TAG);
+
+    xmlContent.append(PROTECT_INFO_TAG);
+    
+    if (kid_.first.size() > 0) {
+        xmlContent.append(KID_START_TAG);
+        xmlContent.append(kid_.first);
+        xmlContent.append(KID_END_TAG);
+    }
+    
+    if (la_url_.length() > 0) {
+        xmlContent.append(LA_URL_START_TAG);
+        xmlContent.append(la_url_);
+        xmlContent.append(LA_URL_END_TAG);
+    }
+    
+    if (lui_url_.length() > 0) {
+        xmlContent.append(LUI_URL_START_TAG);
+        xmlContent.append(lui_url_);
+        xmlContent.append(LUI_URL_END_TAG);
+    }
+    
+    if (kid_.first.size() > 0 && kid_.second.size() > 0) {
+        xmlContent.append(CHECKSUM_START_TAG);
+        xmlContent.append(kid_.second);
+        xmlContent.append(CHECKSUM_END_TAG);
+    }
+    
+    xmlContent.append(DATA_END_TAG); 
+    xmlContent.append(WRMHEADER_END_TAG);
+    output.clear();
+    
+    uint16_t xmlDataSize = static_cast<uint16_t>(xmlContent.size() * 2);
+    //If we do not pack in empty license store we will have only 1 record.
+    uint16_t PrRecordCount = (!include_empty_license_store_)? 1 : 2;
+
+    //RightManager header length + Playready header object size.
+    //PR Header object: Length (uint32_t), PR Record count (uint16_t),
+    //PR Record: Record type (uint16_t), Record length (uint16_t),
+    //           Record value.(the xml content)
+    uint32_t prHeaderObjSize = xmlDataSize + 3 * sizeof(uint16_t) + sizeof(uint32_t);
+   
+    if (include_empty_license_store_) {
+        //Add empty license store size to total length.
+        //Empty license store size is 10KB. In addition
+        //2*sizeof(uint16_t) is required for PlayReady Record header.
+        prHeaderObjSize += 2 * sizeof(uint16_t) + PR_EMBEDDED_LICENSE_STORE_SIZE;
+    }
+    
+    output.insert(output.end(),
+                  reinterpret_cast<uint8_t*>(&prHeaderObjSize),
+                  reinterpret_cast<uint8_t*>(&prHeaderObjSize) +
+                  sizeof(prHeaderObjSize));
+    output.insert(output.end(),
+                  reinterpret_cast<uint8_t*>(&PrRecordCount),
+                  reinterpret_cast<uint8_t*>(&PrRecordCount) +
+                  sizeof(PrRecordCount));
+    output.insert(output.end(),
+                  reinterpret_cast<const uint8_t*>(&PR_RIGHT_MGMT_RECORD_TYPE ),
+                  reinterpret_cast<const uint8_t*>(&PR_RIGHT_MGMT_RECORD_TYPE ) +
+                  sizeof(PR_RIGHT_MGMT_RECORD_TYPE ));
+    output.insert(output.end(),
+                  reinterpret_cast<uint8_t*>(&xmlDataSize),
+                  reinterpret_cast<uint8_t*>(&xmlDataSize) +
+                  sizeof(xmlDataSize));
+    output.insert(output.end(),
+                  reinterpret_cast<const uint8_t*>(xmlContent.data()),
+                  reinterpret_cast<const uint8_t*>(xmlContent.data()) +
+                  (xmlDataSize));
+
+    if (include_empty_license_store_) {
+        output.insert(output.end(),
+                      reinterpret_cast<const uint8_t*>(&PR_EMBEDDED_LICENSE_STORE_RECORD_TYPE),
+                      reinterpret_cast<const uint8_t*>(&PR_EMBEDDED_LICENSE_STORE_RECORD_TYPE) +
+                      sizeof(PR_EMBEDDED_LICENSE_STORE_RECORD_TYPE));
+        output.insert(output.end(),
+                      reinterpret_cast<const uint8_t*>(&PR_EMBEDDED_LICENSE_STORE_SIZE),
+                      reinterpret_cast<const uint8_t*>(&PR_EMBEDDED_LICENSE_STORE_SIZE) +
+                      sizeof(PR_EMBEDDED_LICENSE_STORE_SIZE));
+        output.resize(output.size() + PR_EMBEDDED_LICENSE_STORE_SIZE, 0x00);
+    }
+}
+
+
+bool PlayReadyPsshData::kid_check_sum(const ::std::vector<uint8_t>& KID,
+                                      const ::std::vector<uint8_t>& content_key,
+                                      ::std::string& check_sum) const
+{
+    AES_KEY aeskey;
+    uint8_t cipher_text[AES_BLOCK_SIZE];
+    
+    if (KID.size() != AES_BLOCK_SIZE || content_key.size() != 16) {
+        return false;
+    }
+
+    if (AES_set_encrypt_key(content_key.data(),
+                            128, &aeskey) < 0) {
+        return false;
+    }
+    
+    AES_encrypt(KID.data(), cipher_text, &aeskey);
+
+    memset(&aeskey, 0, sizeof(aeskey));
+
+    check_sum.clear();
+    check_sum.assign(reinterpret_cast<char*>(cipher_text),
+                     PR_KID_CHECKSUM_LENGTH);
+    
+    return true;
+}
+    
+}  // namespace media
+}  // namespace shaka

--- a/packager/media/base/playready_pssh_data.h
+++ b/packager/media/base/playready_pssh_data.h
@@ -1,0 +1,47 @@
+// Copyright 2016 Inside Secure Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+#ifndef MEDIA_BASE_PLAYREADY_PSSH_DATA_H_
+#define MEDIA_BASE_PLAYREADY_PSSH_DATA_H_
+
+#include <string>
+#include <vector>
+#include <utility>
+
+#include "key_source.h"
+
+namespace shaka {
+namespace media {
+
+class PlayReadyPsshData {
+ public:
+    PlayReadyPsshData();
+    
+    bool add_key_info(const EncryptionKey& encryption_key);
+    void set_la_url(const ::std::string& value);
+    void set_lui_url(const ::std::string& value);
+    void set_include_empty_license_store(bool include);
+    
+    void serialize_to_vector(::std::vector<uint8_t>& output) const;
+    
+ private:
+    
+    bool kid_check_sum(const ::std::vector<uint8_t>& KID,
+                       const ::std::vector<uint8_t>& content_key,
+                       ::std::string& check_sum) const;
+    
+    //First is the actual KID. Second is the checksum
+    ::std::pair<::std::u16string, ::std::u16string> kid_;
+    
+    ::std::u16string la_url_;
+    ::std::u16string lui_url_;
+    bool include_empty_license_store_;
+};
+   
+} //namespace media
+} // namespace shaka
+
+#endif //MEDIA_BASE_PLAYREADY_PSSH_DATA_H_

--- a/packager/packager.gyp
+++ b/packager/packager.gyp
@@ -34,6 +34,8 @@
         'app/vlog_flags.h',
         'app/widevine_encryption_flags.cc',
         'app/widevine_encryption_flags.h',
+        'app/playready_encryption_flags.cc',
+        'app/playready_encryption_flags.h',
       ],
       'dependencies': [
         'hls/hls.gyp:hls_builder',


### PR DESCRIPTION
This pull request is related to issue 128. (https://github.com/google/shaka-packager/issues/128)
Adds PlayReady support for VOD use cases when using CENC. Does not still support e.g. live streaming or automatic generation of multiple PSSH boxes (e.g. Widevine + PlayReady) to one mp4 file.