### PR TITLE
Issue 214

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,5 +18,6 @@ Chun-da Chen <capitalm.c@gmail.com>
 Google Inc. <*@google.com>
 Leandro Moreira <leandro.ribeiro.moreira@gmail.com>
 Philo Inc. <*@philo.com>
+Richard Eklycke <richard@eklycke.se>
 Sergio Ammirata <sergio@ammirata.net>
 The Chromium Authors <*@chromium.org>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -31,6 +31,7 @@ Jacob Trimble <modmaker@google.com>
 Joey Parrish <joeyparrish@google.com>
 Kongqun Yang <kqyang@google.com>
 Leandro Moreira <leandro.ribeiro.moreira@gmail.com>
+Richard Eklycke <richard@eklycke.se>
 Rintaro Kuroiwa <rkuroiwa@google.com>
 Sergio Ammirata <sergio@ammirata.net>
 Thomas Inskip <tinskip@google.com>

--- a/packager/media/base/stream_info.h
+++ b/packager/media/base/stream_info.h
@@ -86,7 +86,7 @@ class StreamInfo {
     return encryption_config_;
   }
 
-  void set_duration(int duration) { duration_ = duration; }
+  void set_duration(uint64_t duration) { duration_ = duration; }
   void set_codec(Codec codec) { codec_ = codec; }
   void set_codec_config(const std::vector<uint8_t>& data) { codec_config_ = data; }
   void set_codec_string(const std::string& codec_string) {


### PR DESCRIPTION
This is an attempt to fix issue #214 where it was possible for StreamInfo::set_duration() to overflow, potentially causing the mediaPresentationDuration attribute in the \<MPD\> tag to become corrupted/wrong.