### PR TITLE
Don't do timeshift SlideWindow() logic for static MPD

### DIFF
--- a/packager/mpd/base/mpd_builder.cc
+++ b/packager/mpd/base/mpd_builder.cc
@@ -1308,7 +1308,8 @@ bool Representation::IsContiguous(uint64_t start_time,
 
 void Representation::SlideWindow() {
   DCHECK(!segment_infos_.empty());
-  if (mpd_options_.time_shift_buffer_depth <= 0.0)
+  if (mpd_options_.time_shift_buffer_depth <= 0.0 ||
+      mpd_options_.mpd_type == MpdType::kStatic)
     return;
 
   const uint32_t time_scale = GetTimeScale(media_info_);


### PR DESCRIPTION
This is a fix for issue #216 where the Representation::SlideWindow() logic was
still active even though a static MPD was being asked to be generated (using
the option -generate_static_mpd). This could cause static streams longer than
1800 seconds to start playing at (end-position-for-stream - 1800 seconds).

This change is in compliance with the current usage documentation for the
shaka-packager, which suggests that -time_shift_buffer_depth only is relevant
for dynamic media presentations.