### PR TITLE
Fix typo for ARM cross-compile instructions

### DIFF
--- a/docs/source/build_instructions.md
+++ b/docs/source/build_instructions.md
@@ -215,7 +215,7 @@ The install-build-deps script can be used to install all the compiler
 and library dependencies directly from Ubuntu:
 
 ```shell
-$ ./pacakger/build/install-build-deps.sh
+$ ./packager/build/install-build-deps.sh
 ```
 
 Install sysroot image and others using `gclient`:


### PR DESCRIPTION
Fixed a typo on the instruction for launching the install-build-deps script, needed to install all the cross-compiler and library dependencies on Ubuntu platforms.