### PR TITLE
WebVtt parser: Do not fail when we do not recognize a block

### DIFF
--- a/packager/media/formats/webvtt/webvtt_parser.cc
+++ b/packager/media/formats/webvtt/webvtt_parser.cc
@@ -175,7 +175,8 @@ bool WebVttParser::Parse() {
 
     LOG(ERROR) << "Failed to determine block classification:\n"
                << BlockToString(block.data(), block.size());
-    return false;
+    // Ignore the unknown block
+    continue;
   }
 
   return keep_reading_;


### PR DESCRIPTION
WebVtt parser: Do not fail when we do not recognize a block, just skip it instead