### PR TITLE
Use the ISO639 Language Descriptor when available on the input

### DIFF
--- a/packager/media/formats/mp2t/es_parser_audio.cc
+++ b/packager/media/formats/mp2t/es_parser_audio.cc
@@ -80,11 +80,13 @@ static bool LookForSyncWord(const uint8_t* raw_es,
 
 EsParserAudio::EsParserAudio(uint32_t pid,
                              TsStreamType stream_type,
+                             std::string lang,
                              const NewStreamInfoCB& new_stream_info_cb,
                              const EmitSampleCB& emit_sample_cb,
                              bool sbr_in_mimetype)
     : EsParser(pid),
       stream_type_(stream_type),
+      lang_(lang),
       new_stream_info_cb_(new_stream_info_cb),
       emit_sample_cb_(emit_sample_cb),
       sbr_in_mimetype_(sbr_in_mimetype) {
@@ -213,7 +215,7 @@ bool EsParserAudio::UpdateAudioConfiguration(const AudioHeader& audio_header) {
       audio_specific_config.data(), audio_specific_config.size(),
       kAacSampleSizeBits, audio_header.GetNumChannels(),
       extended_samples_per_second, 0 /* seek preroll */, 0 /* codec delay */,
-      0 /* max bitrate */, 0 /* avg bitrate */, std::string(), false);
+      0 /* max bitrate */, 0 /* avg bitrate */, lang_, false);
 
   DVLOG(1) << "Sampling frequency: " << samples_per_second;
   DVLOG(1) << "Extended sampling frequency: " << extended_samples_per_second;

--- a/packager/media/formats/mp2t/es_parser_audio.h
+++ b/packager/media/formats/mp2t/es_parser_audio.h
@@ -29,6 +29,7 @@ class EsParserAudio : public EsParser {
  public:
   EsParserAudio(uint32_t pid,
                 TsStreamType stream_type,
+                std::string lang,
                 const NewStreamInfoCB& new_stream_info_cb,
                 const EmitSampleCB& emit_sample_cb,
                 bool sbr_in_mimetype);
@@ -56,6 +57,8 @@ class EsParserAudio : public EsParser {
 
   const TsStreamType stream_type_;
   std::unique_ptr<AudioHeader> audio_header_;
+
+  std::string lang_;
 
   // Callbacks:
   // - to signal a new audio configuration,

--- a/packager/media/formats/mp2t/mp2t_media_parser.cc
+++ b/packager/media/formats/mp2t/mp2t_media_parser.cc
@@ -273,10 +273,12 @@ void Mp2tMediaParser::RegisterPmt(int program_number, int pmt_pid) {
 
 void Mp2tMediaParser::RegisterPes(int pmt_pid,
                                   int pes_pid,
-                                  int stream_type) {
+                                  int stream_type,
+                                  std::string lang) {
   DVLOG(1) << "RegisterPes:"
            << " pes_pid=" << pes_pid
-           << " stream_type=" << std::hex << stream_type << std::dec;
+           << " stream_type=" << std::hex << stream_type << std::dec
+           << " lang=" << lang;
   std::map<int, std::unique_ptr<PidState>>::iterator it = pids_.find(pes_pid);
   if (it != pids_.end())
     return;
@@ -300,7 +302,7 @@ void Mp2tMediaParser::RegisterPes(int pmt_pid,
     case TsStreamType::kAdtsAac:
     case TsStreamType::kAc3:
       es_parser.reset(new EsParserAudio(
-          pes_pid, static_cast<TsStreamType>(stream_type),
+          pes_pid, static_cast<TsStreamType>(stream_type), lang,
           base::Bind(&Mp2tMediaParser::OnNewStreamInfo, base::Unretained(this)),
           base::Bind(&Mp2tMediaParser::OnEmitSample, base::Unretained(this)),
           sbr_in_mimetype_));

--- a/packager/media/formats/mp2t/mp2t_media_parser.h
+++ b/packager/media/formats/mp2t/mp2t_media_parser.h
@@ -51,7 +51,7 @@ class Mp2tMediaParser : public MediaParser {
   // Possible values for |media_type| are defined in:
   // ISO-13818.1 / ITU H.222 Table 2.34 "Media type assignments".
   // |pes_pid| is part of the Program Map Table refered by |pmt_pid|.
-  void RegisterPes(int pmt_pid, int pes_pid, int media_type);
+  void RegisterPes(int pmt_pid, int pes_pid, int media_type, std::string lang);
 
   // Callback invoked each time the audio/video decoder configuration is
   // changed.

--- a/packager/media/formats/mp2t/ts_section_pmt.h
+++ b/packager/media/formats/mp2t/ts_section_pmt.h
@@ -18,7 +18,7 @@ class TsSectionPmt : public TsSectionPsi {
   // RegisterPesCb::Run(int pes_pid, int stream_type);
   // Stream type is defined in
   // "Table 2-34 – Stream type assignments" in H.222
-  typedef base::Callback<void(int, int)> RegisterPesCb;
+  typedef base::Callback<void(int, int, std::string)> RegisterPesCb;
 
   explicit TsSectionPmt(const RegisterPesCb& register_pes_cb);
   ~TsSectionPmt() override;


### PR DESCRIPTION
When input is MPEG TS, the language information for audio streams could be available in PMT (ISO639 Language Descriptor).
This commit extracts this information and uses it when needed.

This code was submitted by the github user fpgamaster. All I did was create the pull request.