### PR TITLE
Cleanup condition on `bind` error

### DIFF
--- a/packager/file/udp_file.cc
+++ b/packager/file/udp_file.cc
@@ -199,7 +199,7 @@ bool UdpFile::Open() {
 
   if (bind(new_socket.get(),
            reinterpret_cast<struct sockaddr*>(&local_sock_addr),
-           sizeof(local_sock_addr))) {
+           sizeof(local_sock_addr)) < 0) {
     LOG(ERROR) << "Could not bind UDP socket";
     return false;
   }


### PR DESCRIPTION
### This PR will ...

This PR will cleanup condition for `bind` (`bind` returns `-1` on error)