### PR TITLE
Update general_encryption_options with a better clear_lead description

### DIFF
--- a/docs/source/options/general_encryption_options.rst
+++ b/docs/source/options/general_encryption_options.rst
@@ -13,6 +13,12 @@ General encryption options
 --clear_lead <seconds>
 
     Clear lead in seconds if encryption is enabled.
+    Shaka Packager does not support partial encrypted segments, all the 
+    segments including the partial segment overlapping with the initial 
+    'clear_lead' seconds are not encrypted, with all the following segments 
+    encrypted. If segment_duration is greater than 'clear_lead', then only the
+    first segment is not encrypted.
+    Default: 5
 
 --protection_systems
 


### PR DESCRIPTION
Added a better description to `clear_lead` docs with the same content as defined in the change log (https://github.com/google/shaka-packager/commit/9e9833ea63cf75c2bcd3d1ee8202c92450e5b461). I'm learning about the DRM and it took me hours to figure out why my segments were not being encrypted (similar to https://github.com/google/shaka-player/issues/1883). 