### PR TITLE
Fix problem with default pssh_data

### DIFF
--- a/packager/tools/pssh/pssh-box.py
+++ b/packager/tools/pssh/pssh-box.py
@@ -78,7 +78,7 @@ class Pssh(object):
     self.version = version
     self.system_id = system_id
     self.key_ids = key_ids or []
-    self.pssh_data = pssh_data or ''
+    self.pssh_data = pssh_data or b''
 
   def binary_string(self):
     """Converts the PSSH box to a binary string."""


### PR DESCRIPTION
While creating pssh object if the argument pssh_data is passed as the empty string then default value '' is assigned to pssh_data. Later this value is merging with binary values and error occurs.