### PR TITLE
Fix the error thrown by runhooks command on Windows [Issue 724]

### DIFF
--- a/packager/version/generate_version_string.py
+++ b/packager/version/generate_version_string.py
@@ -32,7 +32,7 @@ if 'check_output' not in dir(subprocess):
 if __name__ == '__main__':
   try:
     version_tag = subprocess.check_output(
-        ['git tag --points-at HEAD'],
+        'git tag --points-at HEAD',
         stderr=subprocess.STDOUT, shell=True).rstrip()
   except subprocess.CalledProcessError as e:
     # git tag --points-at is not supported in old versions of git. Just ignore
@@ -41,7 +41,7 @@ if __name__ == '__main__':
 
   try:
     version_hash = subprocess.check_output(
-        ['git rev-parse --short HEAD'],
+        'git rev-parse --short HEAD',
         stderr=subprocess.STDOUT, shell=True).rstrip()
   except subprocess.CalledProcessError as e:
     version_hash = 'unknown-version'

--- a/packager/version/generate_version_string.py
+++ b/packager/version/generate_version_string.py
@@ -33,7 +33,7 @@ if __name__ == '__main__':
   try:
     version_tag = subprocess.check_output(
         ['git', 'tag', '--points-at', 'HEAD'],
-        stderr=subprocess.STDOUT).rstrip()
+        stderr=subprocess.STDOUT, shell=True).rstrip()
   except subprocess.CalledProcessError as e:
     # git tag --points-at is not supported in old versions of git. Just ignore
     # version_tag in this case.
@@ -42,7 +42,7 @@ if __name__ == '__main__':
   try:
     version_hash = subprocess.check_output(
         ['git', 'rev-parse', '--short', 'HEAD'],
-        stderr=subprocess.STDOUT).rstrip()
+        stderr=subprocess.STDOUT, shell=True).rstrip()
   except subprocess.CalledProcessError as e:
     version_hash = 'unknown-version'
 

--- a/packager/version/generate_version_string.py
+++ b/packager/version/generate_version_string.py
@@ -32,7 +32,7 @@ if 'check_output' not in dir(subprocess):
 if __name__ == '__main__':
   try:
     version_tag = subprocess.check_output(
-        ['git', 'tag', '--points-at', 'HEAD'],
+        ['git tag --points-at HEAD'],
         stderr=subprocess.STDOUT, shell=True).rstrip()
   except subprocess.CalledProcessError as e:
     # git tag --points-at is not supported in old versions of git. Just ignore
@@ -41,7 +41,7 @@ if __name__ == '__main__':
 
   try:
     version_hash = subprocess.check_output(
-        ['git', 'rev-parse', '--short', 'HEAD'],
+        ['git rev-parse --short HEAD'],
         stderr=subprocess.STDOUT, shell=True).rstrip()
   except subprocess.CalledProcessError as e:
     version_hash = 'unknown-version'


### PR DESCRIPTION
As outlined [here](https://github.com/google/shaka-packager/issues/724), the `gclient sync` command was throwing a `python` `subprocess` related error. The call to the subprocess library required an additional `shell=True` argument to be passed in the `generate_version_string.py` file.