### PR TITLE
Fixed build error in Python 3

### DIFF
--- a/packager/tools/generate_license_notice.py
+++ b/packager/tools/generate_license_notice.py
@@ -116,9 +116,9 @@ def GenerateLicenseNotice(output_dir, output_license_file_name):
   license_files.sort()
 
   if output_license_file_name:
-    print 'Num License Files: {}\n'.format(len(license_files))
+    print('Num License Files: {}\n'.format(len(license_files)))
     for license_file in license_files:
-      print license_file
+      print(license_file)
 
   # Include the main license file.
   content = _ReadFile(os.path.join(packager_dir, os.pardir, 'LICENSE'))


### PR DESCRIPTION
Added parentheses to `print` methods to fix the build error.

## build error
The following error occured before this change.

```console
$ python --version
Python 3.7.7

$ gclient config https://www.github.com/google/shaka-packager.git --name=src --unmanaged
...
$ gclient sync
...
$ cd src
$ ninja -C out/Release
ninja: Entering directory `out/Release'
[1/1670] ACTION Generating embeddable license
FAILED: gen/packager/tools/license_notice.cc gen/packager/tools/license_notice.h
cd ../../packager/tools; python generate_license_notice.py /home/user/shaka-packager/src/out/Release/gen/packager/tools
  File "generate_license_notice.py", line 119
    print 'Num License Files: {}\n'.format(len(license_files))
                                  ^
SyntaxError: invalid syntax
[3/1670] CXX obj/third_party/protobuf/src/g...f/util/protobuf_full_do_not_use.time_util.o
ninja: build stopped: subcommand failed.
```