### PR TITLE
Prevent seg fault if there is only an EOS sample on the current segment

### DIFF
--- a/packager/media/formats/webm/segmenter.cc
+++ b/packager/media/formats/webm/segmenter.cc
@@ -150,7 +150,7 @@ Status Segmenter::Initialize(const StreamInfo& info,
 }
 
 Status Segmenter::Finalize() {
-  if (prev_sample_) {
+  if (prev_sample_ && !prev_sample_->end_of_stream()) {
     uint64_t duration =
         prev_sample_->pts() - first_timestamp_ + prev_sample_->duration();
     segment_info_.set_duration(FromBmffTimestamp(duration));


### PR DESCRIPTION
related to #757

I am creating a media server that receives webrtc data via RTP and then uses shaka packager for creating mpeg/dash out.

I finalize the recording by adding an EOS sample at the end of each track, but if there was no other frames received on that segment, I get a segmentation fault on Finalize()