### PR TITLE
Mpeg1 Audio: Support for iso-bmff output, ref #779

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Shaka Packager supports:
   |       VP9         |    I / O     |    I / O     |       -      |      -      |       -      |
   |       AV1         |    I / O     |    I / O     |       -      |      -      |       -      |
   |       AAC         |    I / O     |      -       |     I / O    |      I      |       O      |
-  |       MP3         |      -       |      -       |     I / O    |      -      |       O      |
+  |       MP3         |      O       |      -       |     I / O    |      -      |       O      |
   |    Dolby AC3      |    I / O     |      -       |     I / O    |      -      |       O      |
   |    Dolby EAC3     |    I / O     |      -       |       O      |      -      |       O      |
   |       DTS         |    I / O     |      -       |       -      |      -      |       -      |

--- a/packager/media/codecs/es_descriptor.cc
+++ b/packager/media/codecs/es_descriptor.cc
@@ -168,7 +168,7 @@ void DecoderConfigDescriptor::WriteInternal(BufferWriter* writer) {
   writer->AppendInt(max_bitrate_);
   writer->AppendInt(avg_bitrate_);
 
-  if (!decoder_specific_info_descriptor_is_omitted_)
+  if (!decoder_specific_info_descriptor_.data().empty())
     decoder_specific_info_descriptor_.Write(writer);
 }
 
@@ -176,7 +176,7 @@ size_t DecoderConfigDescriptor::ComputeDataSize() {
   // object_type (1 byte), stream_type (1 byte), decoding_buffer_size (3 bytes),
   // max_bitrate (4 bytes), avg_bitrate (4 bytes).
   const size_t data_size_without_children = 1 + 1 + 3 + 4 + 4;
-  if (decoder_specific_info_descriptor_is_omitted_)
+  if (decoder_specific_info_descriptor_.data().empty())
     return data_size_without_children;
   return data_size_without_children +
          decoder_specific_info_descriptor_.ComputeSize();

--- a/packager/media/codecs/es_descriptor.cc
+++ b/packager/media/codecs/es_descriptor.cc
@@ -167,13 +167,17 @@ void DecoderConfigDescriptor::WriteInternal(BufferWriter* writer) {
   writer->AppendNBytes(buffer_size_db_, 3);
   writer->AppendInt(max_bitrate_);
   writer->AppendInt(avg_bitrate_);
-  decoder_specific_info_descriptor_.Write(writer);
+
+  if (!decoder_specific_info_descriptor_is_ommited_)
+    decoder_specific_info_descriptor_.Write(writer);
 }
 
 size_t DecoderConfigDescriptor::ComputeDataSize() {
   // object_type (1 byte), stream_type (1 byte), decoding_buffer_size (3 bytes),
   // max_bitrate (4 bytes), avg_bitrate (4 bytes).
   const size_t data_size_without_children = 1 + 1 + 3 + 4 + 4;
+  if (decoder_specific_info_descriptor_is_ommited_)
+    return data_size_without_children;
   return data_size_without_children +
          decoder_specific_info_descriptor_.ComputeSize();
 }

--- a/packager/media/codecs/es_descriptor.cc
+++ b/packager/media/codecs/es_descriptor.cc
@@ -168,7 +168,7 @@ void DecoderConfigDescriptor::WriteInternal(BufferWriter* writer) {
   writer->AppendInt(max_bitrate_);
   writer->AppendInt(avg_bitrate_);
 
-  if (!decoder_specific_info_descriptor_is_ommited_)
+  if (!decoder_specific_info_descriptor_is_omitted_)
     decoder_specific_info_descriptor_.Write(writer);
 }
 
@@ -176,7 +176,7 @@ size_t DecoderConfigDescriptor::ComputeDataSize() {
   // object_type (1 byte), stream_type (1 byte), decoding_buffer_size (3 bytes),
   // max_bitrate (4 bytes), avg_bitrate (4 bytes).
   const size_t data_size_without_children = 1 + 1 + 3 + 4 + 4;
-  if (decoder_specific_info_descriptor_is_ommited_)
+  if (decoder_specific_info_descriptor_is_omitted_)
     return data_size_without_children;
   return data_size_without_children +
          decoder_specific_info_descriptor_.ComputeSize();

--- a/packager/media/codecs/es_descriptor.h
+++ b/packager/media/codecs/es_descriptor.h
@@ -144,7 +144,7 @@ class DecoderConfigDescriptor : public BaseDescriptor {
   }
 
   void omit_decoder_specific_info_descriptor() {
-    decoder_specific_info_descriptor_is_ommited_ = true;
+    decoder_specific_info_descriptor_is_omitted_ = true;
   }
 
  private:
@@ -156,7 +156,7 @@ class DecoderConfigDescriptor : public BaseDescriptor {
   uint32_t buffer_size_db_ = 0;
   uint32_t max_bitrate_ = 0;
   uint32_t avg_bitrate_ = 0;
-  bool decoder_specific_info_descriptor_is_ommited_ = false;
+  bool decoder_specific_info_descriptor_is_omitted_ = false;
   DecoderSpecificInfoDescriptor decoder_specific_info_descriptor_;
 };
 

--- a/packager/media/codecs/es_descriptor.h
+++ b/packager/media/codecs/es_descriptor.h
@@ -143,10 +143,6 @@ class DecoderConfigDescriptor : public BaseDescriptor {
     return &decoder_specific_info_descriptor_;
   }
 
-  void omit_decoder_specific_info_descriptor() {
-    decoder_specific_info_descriptor_is_omitted_ = true;
-  }
-
  private:
   bool ReadData(BitReader* reader) override;
   void WriteInternal(BufferWriter* writer) override;
@@ -156,7 +152,6 @@ class DecoderConfigDescriptor : public BaseDescriptor {
   uint32_t buffer_size_db_ = 0;
   uint32_t max_bitrate_ = 0;
   uint32_t avg_bitrate_ = 0;
-  bool decoder_specific_info_descriptor_is_omitted_ = false;
   DecoderSpecificInfoDescriptor decoder_specific_info_descriptor_;
 };
 

--- a/packager/media/codecs/es_descriptor.h
+++ b/packager/media/codecs/es_descriptor.h
@@ -22,6 +22,8 @@ enum class ObjectType : uint8_t {
   kForbidden = 0,
   kISO_14496_3 = 0x40,         // MPEG4 AAC
   kISO_13818_7_AAC_LC = 0x67,  // MPEG2 AAC-LC
+  kISO_13818_3_MPEG1 = 0x69,   // MPEG1 ISO/IEC 13818-3, 16,22.05,24kHz
+  kISO_11172_3_MPEG1 = 0x6B,   // MPEG1 ISO/IEC 11172-3, 32,44.1,48kHz
   kDTSC = 0xA9,                // DTS Coherent Acoustics audio
   kDTSE = 0xAC,                // DTS Express low bit rate audio
   kDTSH = 0xAA,                // DTS-HD High Resolution Audio
@@ -141,6 +143,10 @@ class DecoderConfigDescriptor : public BaseDescriptor {
     return &decoder_specific_info_descriptor_;
   }
 
+  void omit_decoder_specific_info_descriptor() {
+    decoder_specific_info_descriptor_is_ommited_ = true;
+  }
+
  private:
   bool ReadData(BitReader* reader) override;
   void WriteInternal(BufferWriter* writer) override;
@@ -150,6 +156,7 @@ class DecoderConfigDescriptor : public BaseDescriptor {
   uint32_t buffer_size_db_ = 0;
   uint32_t max_bitrate_ = 0;
   uint32_t avg_bitrate_ = 0;
+  bool decoder_specific_info_descriptor_is_ommited_ = false;
   DecoderSpecificInfoDescriptor decoder_specific_info_descriptor_;
 };
 

--- a/packager/media/formats/mp4/mp4_muxer.cc
+++ b/packager/media/formats/mp4/mp4_muxer.cc
@@ -67,6 +67,7 @@ FourCC CodecToFourCC(Codec codec, H26xStreamFormat h26x_stream_format) {
     case kCodecVP9:
       return FOURCC_vp09;
     case kCodecAAC:
+    case kCodecMP3:
       return FOURCC_mp4a;
     case kCodecAC3:
       return FOURCC_ac_3;
@@ -487,6 +488,26 @@ bool MP4Muxer::GenerateAudioTrak(const AudioStreamInfo* audio_info,
     case kCodecFlac:
       audio.dfla.data = audio_info->codec_config();
       break;
+    case kCodecMP3: {
+      audio.esds.es_descriptor.set_esid(track_id);
+      DecoderConfigDescriptor* decoder_config =
+          audio.esds.es_descriptor.mutable_decoder_config_descriptor();
+      uint32_t samplerate = audio_info->sampling_frequency();
+      if (samplerate < 32000)
+        decoder_config->set_object_type(ObjectType::kISO_13818_3_MPEG1);
+      else
+        decoder_config->set_object_type(ObjectType::kISO_11172_3_MPEG1);
+      decoder_config->set_max_bitrate(audio_info->max_bitrate());
+      decoder_config->set_avg_bitrate(audio_info->avg_bitrate());
+
+      // For values of DecoderConfigDescriptor.objectTypeIndication
+      // that refer to streams complying with ISO/IEC 11172-3 or
+      // ISO/IEC 13818-3 the decoder specific information is empty
+      // since all necessary data is contained in the bitstream frames
+      // itself.
+      decoder_config->omit_decoder_specific_info_descriptor();
+      break;
+    }
     case kCodecOpus:
       audio.dops.opus_identification_header = audio_info->codec_config();
       break;

--- a/packager/media/formats/mp4/mp4_muxer.cc
+++ b/packager/media/formats/mp4/mp4_muxer.cc
@@ -505,7 +505,6 @@ bool MP4Muxer::GenerateAudioTrak(const AudioStreamInfo* audio_info,
       // ISO/IEC 13818-3 the decoder specific information is empty
       // since all necessary data is contained in the bitstream frames
       // itself.
-      decoder_config->omit_decoder_specific_info_descriptor();
       break;
     }
     case kCodecOpus:


### PR DESCRIPTION
- Makes possible to pack mpeg1 audio streams into .mp4 files