### PR TITLE
Allow IV to be specified in the "key_info_string"

### DIFF
--- a/docs/source/options/raw_key_encryption_options.rst
+++ b/docs/source/options/raw_key_encryption_options.rst
@@ -17,7 +17,7 @@ Raw key encryption options
 
     **key_info_string** is of the form::
 
-        label=<label>:key_id=<key_id>:key=<key>
+        label=<label>:key_id=<key_id>:key=<key>[:iv=<initialization_vector>]
 
     *label* can be an arbitrary string or a predefined DRM label like AUDIO,
     SD, HD, etc. Label with an empty string indicates the default key and
@@ -26,6 +26,10 @@ Raw key encryption options
     by matching the *drm_label* with the *label* in key info.
 
     *key_id* and *key* should be 32-digit hex strings.
+
+    *initialization_vector* is an optional IV with the same format and semantics
+    as the parameter for the --iv option below. This is mutually exclusive with
+    that option.
 
 --iv <16-digit or 32-digit hex string>
 

--- a/docs/source/tutorials/raw_key.rst
+++ b/docs/source/tutorials/raw_key.rst
@@ -20,7 +20,7 @@ Synopsis
 
 **key_info_string** is of the form::
 
-    label=<label>:key_id=<key_id>:key=<key>
+    label=<label>:key_id=<key_id>:key=<key>[:iv=<initialization_vector>]
 
 Custom PSSH(s) can be provided in *--pssh*. If neither --pssh nor
 --protection_systems is specified, `v1 common PSSH box <https://goo.gl/s8RIhr>`_

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -118,6 +118,7 @@ const char kUsage[] =
 const char kDrmLabelLabel[] = "label";
 const char kKeyIdLabel[] = "key_id";
 const char kKeyLabel[] = "key";
+const char kKeyIvLabel[] = "iv";
 
 enum ExitStatus {
   kSuccess = 0,
@@ -206,6 +207,17 @@ bool ParseKeys(const std::string& keys, RawKeyParams* raw_key) {
       LOG(ERROR) << "Empty key or invalid hex string for key: "
                  << value_map[kKeyLabel];
       return false;
+    }
+    if (!value_map[kKeyIvLabel].empty()) {
+      if (!raw_key->iv.empty()) {
+        LOG(ERROR) << "IV already specified with --iv";
+        return false;
+      }
+      if (!base::HexStringToBytes(value_map[kKeyIvLabel], &key_info.iv)) {
+        LOG(ERROR) << "Empty key or invalid hex string for IV: "
+                   << value_map[kKeyIvLabel];
+        return false;
+      }
     }
   }
   return true;

--- a/packager/media/base/raw_key_source.cc
+++ b/packager/media/base/raw_key_source.cc
@@ -127,11 +127,16 @@ std::unique_ptr<RawKeySource> RawKeySource::Create(
                  << "', must be 16 bytes.";
       return std::unique_ptr<RawKeySource>();
     }
+    if (!key_pair.iv.empty() && key_pair.iv.size() != 8 && key_pair.iv.size() != 16) {
+      LOG(ERROR) << "Invalid IV '" << key_pair.iv.size()
+                 << "', must be 8 or 16 bytes.";
+      return std::unique_ptr<RawKeySource>();
+    }
 
     std::unique_ptr<EncryptionKey> encryption_key(new EncryptionKey);
     encryption_key->key_id = key_pair.key_id;
     encryption_key->key = key_pair.key;
-    encryption_key->iv = raw_key.iv;
+    encryption_key->iv = (key_pair.iv.empty()) ? raw_key.iv : key_pair.iv;
     encryption_key->key_system_info = key_system_info;
     encryption_key_map[drm_label] = std::move(encryption_key);
   }

--- a/packager/media/public/crypto_params.h
+++ b/packager/media/public/crypto_params.h
@@ -134,6 +134,7 @@ struct RawKeyParams {
   struct KeyInfo {
     std::vector<uint8_t> key_id;
     std::vector<uint8_t> key;
+    std::vector<uint8_t> iv;
   };
   /// Defines the KeyInfo for the streams. An empty `StreamLabel` indicates the
   /// default `KeyInfo`, which applies to all the `StreamLabels` not present in


### PR DESCRIPTION
Allow an optional initialization vector to be specified as `iv` in the "key_info_string" for raw key encryption. This is for use in conjunction with FairPlay where the IV will be delivered from the KSM, not the randomized one otherwise supplied in the `tenc` box. The `--iv` option is mutually exclusive with this key parameter.