### PR TITLE
Adding support for generation of the EXT_X_PROGRAM_DATE_TIME tag for …

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -30,3 +30,4 @@ Richard Eklycke <richard@eklycke.se>
 Sanil Raut <sr1990003@gmail.com>
 Sergio Ammirata <sergio@ammirata.net>
 The Chromium Authors <*@chromium.org>
+cdnnow! <*@cdnnow.pro>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -24,6 +24,7 @@
 
 Alen Vrecko <alen.vrecko@gmail.com>
 Anders Hasselqvist <anders.hasselqvist@gmail.com>
+Artem Bogdanov <ykidia@gmail.com>
 Bei Li <beil@google.com>
 Chun-da Chen <capitalm.c@gmail.com>
 Daniel Cantarín <canta@canta.com.ar>
@@ -45,4 +46,3 @@ Sergio Ammirata <sergio@ammirata.net>
 Thomas Inskip <tinskip@google.com>
 Tim Lansen <tim.lansen@gmail.com>
 Weiguo Shao <weiguo.shao@dolby.com>
-Artem Bogdanov <ykidia@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -45,3 +45,4 @@ Sergio Ammirata <sergio@ammirata.net>
 Thomas Inskip <tinskip@google.com>
 Tim Lansen <tim.lansen@gmail.com>
 Weiguo Shao <weiguo.shao@dolby.com>
+Artem Bogdanov <ykidia@gmail.com>

--- a/docs/source/options/hls_options.rst
+++ b/docs/source/options/hls_options.rst
@@ -76,6 +76,12 @@ HLS options
     The EXT-X-MEDIA-SEQUENCE documentation can be read here:
     https://tools.ietf.org/html/rfc8216#section-4.3.3.2.
 
+
+--hls_ext_x_program_date_time
+
+    Adds an EXT-X-PROGRAM-DATE-TIME tag to every Media Segment, with fixed UTC
+    timezone.
+
 --hls_only=0|1
 
     Optional. Defaults to 0 if not specified. If it is set to 1, indicates the

--- a/packager/app/hls_flags.cc
+++ b/packager/app/hls_flags.cc
@@ -30,3 +30,6 @@ DEFINE_int32(hls_media_sequence_number,
               "EXT-X-MEDIA-SEQUENCE value, which allows continuous media "
               "sequence across packager restarts. See #691 for more "
               "information about the reasoning of this and its use cases.");
+DEFINE_bool(hls_ext_x_program_date_time,
+              false,
+              "Enable generation of EXT-X-PROGRAM-DATE-TIME tag");

--- a/packager/app/hls_flags.h
+++ b/packager/app/hls_flags.h
@@ -14,5 +14,6 @@ DECLARE_string(hls_base_url);
 DECLARE_string(hls_key_uri);
 DECLARE_string(hls_playlist_type);
 DECLARE_int32(hls_media_sequence_number);
+DECLARE_bool(hls_ext_x_program_date_time);
 
 #endif  // PACKAGER_APP_HLS_FLAGS_H_

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -489,6 +489,7 @@ base::Optional<PackagingParams> GetPackagingParams() {
   hls_params.default_language = FLAGS_default_language;
   hls_params.default_text_language = FLAGS_default_text_language;
   hls_params.media_sequence_number = FLAGS_hls_media_sequence_number;
+  hls_params.hls_ext_x_program_date_time = FLAGS_hls_ext_x_program_date_time;
 
   TestParams& test_params = packaging_params.test_params;
   test_params.dump_stream_info = FLAGS_dump_stream_info;

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -489,7 +489,7 @@ base::Optional<PackagingParams> GetPackagingParams() {
   hls_params.default_language = FLAGS_default_language;
   hls_params.default_text_language = FLAGS_default_text_language;
   hls_params.media_sequence_number = FLAGS_hls_media_sequence_number;
-  hls_params.hls_ext_x_program_date_time = FLAGS_hls_ext_x_program_date_time;
+  hls_params.ext_x_program_date_time = FLAGS_hls_ext_x_program_date_time;
 
   TestParams& test_params = packaging_params.test_params;
   test_params.dump_stream_info = FLAGS_dump_stream_info;

--- a/packager/hls/base/media_playlist.cc
+++ b/packager/hls/base/media_playlist.cc
@@ -12,6 +12,7 @@
 #include <cmath>
 #include <memory>
 
+#include "packager/app/hls_flags.h"
 #include "packager/base/logging.h"
 #include "packager/base/strings/string_number_conversions.h"
 #include "packager/base/strings/stringprintf.h"
@@ -21,7 +22,6 @@
 #include "packager/media/base/language_utils.h"
 #include "packager/media/base/muxer_util.h"
 #include "packager/version/version.h"
-#include "packager/app/hls_flags.h"
 
 namespace shaka {
 namespace hls {
@@ -176,7 +176,7 @@ class SegmentInfoEntry : public HlsEntry {
                    uint64_t segment_file_size,
                    uint64_t previous_segment_end_offset,
                    bool use_program_date_time,
-                   double start_timestamp);
+                   double program_date_time);
 
   std::string ToString() override;
   int64_t start_time() const { return start_time_; }
@@ -197,7 +197,7 @@ class SegmentInfoEntry : public HlsEntry {
   const uint64_t segment_file_size_;
   const uint64_t previous_segment_end_offset_;
   const bool use_program_date_time_;
-  const double start_timestamp_;
+  const double program_date_time_;
 };
 
 SegmentInfoEntry::SegmentInfoEntry(const std::string& file_name,
@@ -208,7 +208,7 @@ SegmentInfoEntry::SegmentInfoEntry(const std::string& file_name,
                                    uint64_t segment_file_size,
                                    uint64_t previous_segment_end_offset,
                                    bool use_program_date_time,
-                                   double start_timestamp)
+                                   double program_date_time)
     : HlsEntry(HlsEntry::EntryType::kExtInf),
       file_name_(file_name),
       start_time_(start_time),
@@ -218,14 +218,14 @@ SegmentInfoEntry::SegmentInfoEntry(const std::string& file_name,
       segment_file_size_(segment_file_size),
       previous_segment_end_offset_(previous_segment_end_offset),
       use_program_date_time_(use_program_date_time),
-      start_timestamp_(start_timestamp) {}
+      program_date_time_(program_date_time) {}
 
 std::string SegmentInfoEntry::ToString() {
   std::string result = base::StringPrintf("#EXTINF:%.3f,", duration_seconds_);
 
   if (use_program_date_time_) {
     base::Time::Exploded time;
-    base::Time::FromDoubleT(start_timestamp_).UTCExplode(&time);
+    base::Time::FromDoubleT(program_date_time_).UTCExplode(&time);
 
     std::string date_time = base::StringPrintf("%4d-%02d-%02dT%02d:%02d:%02d.%03dZ", time.year,
                             time.month, time.day_of_month,

--- a/packager/hls/base/media_playlist.cc
+++ b/packager/hls/base/media_playlist.cc
@@ -22,6 +22,7 @@
 #include "packager/media/base/language_utils.h"
 #include "packager/media/base/muxer_util.h"
 #include "packager/version/version.h"
+#include "packager/app/hls_flags.h"
 
 //DEFINE_bool(hls_ext_x_program_date_time,
 //            false,

--- a/packager/hls/base/media_playlist.cc
+++ b/packager/hls/base/media_playlist.cc
@@ -23,9 +23,9 @@
 #include "packager/media/base/muxer_util.h"
 #include "packager/version/version.h"
 
-DEFINE_bool(hls_ext_x_program_date_time,
-            false,
-            "hls print EXT-X-PROGRAM-DATE-TIME tag");
+//DEFINE_bool(hls_ext_x_program_date_time,
+//            false,
+//            "hls print EXT-X-PROGRAM-DATE-TIME tag");
 
 namespace shaka {
 namespace hls {
@@ -368,7 +368,7 @@ MediaPlaylist::MediaPlaylist(const HlsParams& hls_params,
       name_(name),
       group_id_(group_id),
       media_sequence_number_(hls_params_.media_sequence_number) {
-        start_timestamp = base::Time::Now().ToDoubleT();
+        start_timestamp_ = base::Time::Now().ToDoubleT();
 
         // When there's a forced media_sequence_number, start with discontinuity
         if (media_sequence_number_ > 0)
@@ -448,15 +448,15 @@ void MediaPlaylist::AddSegment(const std::string& file_name,
                                          : std::next(iter)->timestamp;
       AddSegmentInfoEntry(file_name, iter->timestamp,
                           next_timestamp - iter->timestamp,
-                          iter->start_byte_offset, iter->size, start_timestamp);
+                          iter->start_byte_offset, iter->size, start_timestamp_);
     }
     key_frames_.clear();
   } else {
     AddSegmentInfoEntry(file_name, start_time, duration, start_byte_offset, size,
-                        start_timestamp);
+                        start_timestamp_);
   }
 
-  start_timestamp += static_cast<double>(duration) / time_scale_;
+  start_timestamp_ += static_cast<double>(duration) / time_scale_;
 }
 
 void MediaPlaylist::AddKeyFrame(int64_t timestamp,
@@ -605,7 +605,7 @@ double MediaPlaylist::GetFrameRate() const {
 }
 
 double MediaPlaylist::GetStartTimeStamp() const {
-    return start_timestamp;
+    return start_timestamp_;
 }
 
 void MediaPlaylist::AddSegmentInfoEntry(const std::string& segment_file_name,

--- a/packager/hls/base/media_playlist.h
+++ b/packager/hls/base/media_playlist.h
@@ -273,7 +273,9 @@ class MediaPlaylist {
   bool target_duration_set_ = false;
   uint32_t target_duration_ = 0;
 
-  double start_timestamp = 0;
+  // Time stamp for SegmentInfoEntry in the "entries_" list.
+  // This is used for tag EXT-X-PROGRAM-DATE-TIME generation.
+  double start_timestamp_ = 0;
 
   // TODO(kqyang): This could be managed better by a separate class, than having
   // all them managed in MediaPlaylist.

--- a/packager/hls/base/media_playlist.h
+++ b/packager/hls/base/media_playlist.h
@@ -213,6 +213,10 @@ class MediaPlaylist {
   /// @return the frame rate.
   virtual double GetFrameRate() const;
 
+  /// @return time stamp
+  /// For testing only.
+  virtual double GetStartTimeStamp() const;
+
   /// @return the language of the media, as an ISO language tag in its shortest
   ///         form.  May be an empty string for video.
   const std::string& language() const { return language_; }
@@ -227,7 +231,8 @@ class MediaPlaylist {
                            int64_t start_time,
                            int64_t duration,
                            uint64_t start_byte_offset,
-                           uint64_t size);
+                           uint64_t size,
+                           double start_timestamp);
   // Adjust the duration of the last SegmentInfoEntry to end on
   // |next_timestamp|.
   void AdjustLastSegmentInfoEntryDuration(int64_t next_timestamp);
@@ -267,6 +272,8 @@ class MediaPlaylist {
   // See SetTargetDuration() comments.
   bool target_duration_set_ = false;
   uint32_t target_duration_ = 0;
+
+  double start_timestamp = 0;
 
   // TODO(kqyang): This could be managed better by a separate class, than having
   // all them managed in MediaPlaylist.

--- a/packager/hls/base/media_playlist_unittest.cc
+++ b/packager/hls/base/media_playlist_unittest.cc
@@ -16,7 +16,7 @@
 #include "packager/hls/base/media_playlist.h"
 #include "packager/version/version.h"
 
-DECLARE_bool(hls_ext_x_program_date_time);
+//DECLARE_bool(hls_ext_x_program_date_time);
 
 namespace shaka {
 namespace hls {
@@ -353,41 +353,6 @@ TEST_F(MediaPlaylistMultiSegmentTest, SetTargetDuration) {
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
   EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
-  ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
-}
-
-TEST_F(MediaPlaylistMultiSegmentTest, WriteToFileWithTagExtXProgramDateTime) {
-  valid_video_media_info_.set_reference_time_scale(90000);
-  ASSERT_TRUE(media_playlist_->SetMediaInfo(valid_video_media_info_));
-
-  auto prev_flag_state = FLAGS_hls_ext_x_program_date_time;
-  FLAGS_hls_ext_x_program_date_time = true;
-
-  const std::string date_time1 = timestampToString(media_playlist_->GetStartTimeStamp());
-  media_playlist_->AddSegment("file1.ts", 0, 10 * kTimeScale, kZeroByteOffset,
-                              kMBytes);
-  const std::string date_time2 = timestampToString(media_playlist_->GetStartTimeStamp());
-  media_playlist_->AddSegment("file2.ts", 10 * kTimeScale, 30 * kTimeScale,
-                              kZeroByteOffset, 5 * kMBytes);
-  std::string kExpectedOutput = base::StringPrintf(
-      "#EXTM3U\n"
-      "#EXT-X-VERSION:6\n"
-      "## Generated with https://github.com/google/shaka-packager version "
-      "test\n"
-      "#EXT-X-TARGETDURATION:30\n"
-      "#EXT-X-PLAYLIST-TYPE:VOD\n"
-      "#EXTINF:10.000,\n"
-      "#EXT-X-PROGRAM-DATE-TIME:%s\n"
-      "file1.ts\n"
-      "#EXTINF:30.000,\n"
-      "#EXT-X-PROGRAM-DATE-TIME:%s\n"
-      "file2.ts\n"
-      "#EXT-X-ENDLIST\n",
-          date_time1.c_str(), date_time2.c_str());
-
-  const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
-  FLAGS_hls_ext_x_program_date_time = prev_flag_state;
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -804,41 +769,6 @@ TEST_F(LiveMediaPlaylistTest, TimeShifted) {
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
-TEST_F(LiveMediaPlaylistTest, TimeShiftedWithTagExtXProgramDateTime) {
-  ASSERT_TRUE(media_playlist_->SetMediaInfo(valid_video_media_info_));
-
-  auto prev_flag_state = FLAGS_hls_ext_x_program_date_time;
-  FLAGS_hls_ext_x_program_date_time = true;
-
-  media_playlist_->AddSegment("file1.ts", 0, 10 * kTimeScale, kZeroByteOffset,
-                              kMBytes);
-  const std::string date_time1 = timestampToString(media_playlist_->GetStartTimeStamp());
-  media_playlist_->AddSegment("file2.ts", 10 * kTimeScale, 20 * kTimeScale,
-                              kZeroByteOffset, 2 * kMBytes);
-  const std::string date_time2 = timestampToString(media_playlist_->GetStartTimeStamp());
-  media_playlist_->AddSegment("file3.ts", 30 * kTimeScale, 20 * kTimeScale,
-                              kZeroByteOffset, 2 * kMBytes);
-  std::string kExpectedOutput = base::StringPrintf(
-      "#EXTM3U\n"
-      "#EXT-X-VERSION:6\n"
-      "## Generated with https://github.com/google/shaka-packager version "
-      "test\n"
-      "#EXT-X-TARGETDURATION:20\n"
-      "#EXT-X-MEDIA-SEQUENCE:1\n"
-      "#EXTINF:20.000,\n"
-      "#EXT-X-PROGRAM-DATE-TIME:%s\n"
-      "file2.ts\n"
-      "#EXTINF:20.000,\n"
-      "#EXT-X-PROGRAM-DATE-TIME:%s\n"
-      "file3.ts\n",
-          date_time1.c_str(), date_time2.c_str());
-
-  const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
-  FLAGS_hls_ext_x_program_date_time = prev_flag_state;
-  ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
-}
-
 TEST_F(LiveMediaPlaylistTest, TimeShiftedWithEncryptionInfo) {
   ASSERT_TRUE(media_playlist_->SetMediaInfo(valid_video_media_info_));
 
@@ -976,39 +906,6 @@ TEST_F(EventMediaPlaylistTest, Basic) {
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
-TEST_F(EventMediaPlaylistTest, BasicWithTagExtXProgramDateTime) {
-  ASSERT_TRUE(media_playlist_->SetMediaInfo(valid_video_media_info_));
-
-  auto prev_flag_state = FLAGS_hls_ext_x_program_date_time;
-  FLAGS_hls_ext_x_program_date_time = true;
-
-  const std::string date_time1 = timestampToString(media_playlist_->GetStartTimeStamp());
-  media_playlist_->AddSegment("file1.ts", 0, 10 * kTimeScale, kZeroByteOffset,
-                              kMBytes);
-  const std::string date_time2 = timestampToString(media_playlist_->GetStartTimeStamp());
-  media_playlist_->AddSegment("file2.ts", 10 * kTimeScale, 20 * kTimeScale,
-                              kZeroByteOffset, 2 * kMBytes);
-  std::string kExpectedOutput = base::StringPrintf(
-      "#EXTM3U\n"
-      "#EXT-X-VERSION:6\n"
-      "## Generated with https://github.com/google/shaka-packager version "
-      "test\n"
-      "#EXT-X-TARGETDURATION:20\n"
-      "#EXT-X-PLAYLIST-TYPE:EVENT\n"
-      "#EXTINF:10.000,\n"
-      "#EXT-X-PROGRAM-DATE-TIME:%s\n"
-      "file1.ts\n"
-      "#EXTINF:20.000,\n"
-      "#EXT-X-PROGRAM-DATE-TIME:%s\n"
-      "file2.ts\n",
-          date_time1.c_str(), date_time2.c_str());
-
-  const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
-  FLAGS_hls_ext_x_program_date_time = prev_flag_state;
-  ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
-}
-
 class IFrameMediaPlaylistTest : public MediaPlaylistTest {};
 
 TEST_F(IFrameMediaPlaylistTest, MediaPlaylistType) {
@@ -1062,61 +959,6 @@ TEST_F(IFrameMediaPlaylistTest, SingleSegment) {
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
   EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
-  ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
-}
-
-TEST_F(IFrameMediaPlaylistTest, SingleSegmentWithTagExtXProgramDateTime) {
-  valid_video_media_info_.set_media_file_url("file.mp4");
-  valid_video_media_info_.mutable_init_range()->set_begin(0);
-  valid_video_media_info_.mutable_init_range()->set_end(500);
-  auto prev_flag_state = FLAGS_hls_ext_x_program_date_time;
-  FLAGS_hls_ext_x_program_date_time = true;
-
-  ASSERT_TRUE(media_playlist_->SetMediaInfo(valid_video_media_info_));
-  const std::string date_time1 = timestampToString(media_playlist_->GetStartTimeStamp());
-  media_playlist_->AddKeyFrame(0, 1000, 2345);
-  const std::string date_time2 = timestampToString(media_playlist_->GetStartTimeStamp());
-  media_playlist_->AddKeyFrame(2 * kTimeScale, 5000, 6345);
-  media_playlist_->AddSegment("file.mp4", 0, 10 * kTimeScale, kZeroByteOffset,
-                              kMBytes);
-  const std::string date_time3 = timestampToString(media_playlist_->GetStartTimeStamp());
-  media_playlist_->AddKeyFrame(11 * kTimeScale, kMBytes + 1000, 2345);
-  const std::string date_time4 = timestampToString(media_playlist_->GetStartTimeStamp());
-  media_playlist_->AddKeyFrame(15 * kTimeScale, kMBytes + 3345, 12345);
-  media_playlist_->AddSegment("file.mp4", 10 * kTimeScale, 10 * kTimeScale,
-                              1001000, 2 * kMBytes);
-
-  const std::string kExpectedOutput = base::StringPrintf(
-      "#EXTM3U\n"
-      "#EXT-X-VERSION:6\n"
-      "## Generated with https://github.com/google/shaka-packager version "
-      "test\n"
-      "#EXT-X-TARGETDURATION:9\n"
-      "#EXT-X-PLAYLIST-TYPE:VOD\n"
-      "#EXT-X-I-FRAMES-ONLY\n"
-      "#EXT-X-MAP:URI=\"file.mp4\",BYTERANGE=\"501@0\"\n"
-      "#EXTINF:2.000,\n"
-      "#EXT-X-PROGRAM-DATE-TIME:%s\n"
-      "#EXT-X-BYTERANGE:2345@1000\n"
-      "file.mp4\n"
-      "#EXTINF:9.000,\n"
-      "#EXT-X-PROGRAM-DATE-TIME:%s\n"
-      "#EXT-X-BYTERANGE:6345@5000\n"
-      "file.mp4\n"
-      "#EXTINF:4.000,\n"
-      "#EXT-X-PROGRAM-DATE-TIME:%s\n"
-      "#EXT-X-BYTERANGE:2345@1001000\n"
-      "file.mp4\n"
-      "#EXTINF:5.000,\n"
-      "#EXT-X-PROGRAM-DATE-TIME:%s\n"
-      "#EXT-X-BYTERANGE:12345\n"
-      "file.mp4\n"
-      "#EXT-X-ENDLIST\n",
-          date_time1.c_str(), date_time2.c_str(), date_time3.c_str(), date_time4.c_str());
-
-  const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
-  FLAGS_hls_ext_x_program_date_time = prev_flag_state;
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 

--- a/packager/hls/base/media_playlist_unittest.cc
+++ b/packager/hls/base/media_playlist_unittest.cc
@@ -6,7 +6,6 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <gflags/gflags.h>
 
 #include "packager/base/time/time.h"
 #include "packager/base/strings/stringprintf.h"
@@ -15,6 +14,7 @@
 #include "packager/file/file_test_util.h"
 #include "packager/hls/base/media_playlist.h"
 #include "packager/version/version.h"
+#include "packager/app/hls_flags.h"
 
 //DECLARE_bool(hls_ext_x_program_date_time);
 

--- a/packager/hls/base/media_playlist_unittest.cc
+++ b/packager/hls/base/media_playlist_unittest.cc
@@ -6,13 +6,17 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <gflags/gflags.h>
 
+#include "packager/base/time/time.h"
 #include "packager/base/strings/stringprintf.h"
 #include "packager/file/file.h"
 #include "packager/file/file_closer.h"
 #include "packager/file/file_test_util.h"
 #include "packager/hls/base/media_playlist.h"
 #include "packager/version/version.h"
+
+DECLARE_bool(hls_ext_x_program_date_time);
 
 namespace shaka {
 namespace hls {
@@ -30,6 +34,18 @@ const double kTimeShiftBufferDepth = 20;
 const uint64_t kTimeScale = 90000;
 const uint64_t kMBytes = 1000000;
 const uint64_t kZeroByteOffset = 0;
+
+// Converts timestamp to ISO/IEC 8601:2004 date/time representation,
+//  such as YYYY-MM-DDThh:mm:ss.SSSZ
+std::string timestampToString(double ts) {
+  const char date_time_tmpl[] = "%4d-%02d-%02dT%02d:%02d:%02d.%03dZ";
+  base::Time::Exploded time;
+  base::Time::FromDoubleT(ts).UTCExplode(&time);
+  return base::StringPrintf(
+      date_time_tmpl,
+      time.year, time.month, time.day_of_month,
+      time.hour, time.minute, time.second, time.millisecond);
+}
 
 MATCHER_P(MatchesString, expected_string, "") {
   const std::string arg_string(static_cast<const char*>(arg));
@@ -223,6 +239,47 @@ TEST_F(MediaPlaylistSingleSegmentTest, AddSegmentByteRange) {
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
+TEST_F(MediaPlaylistSingleSegmentTest, AddSegmentByteRangeWithTagExtXProgramDateTime) {
+  valid_video_media_info_.set_media_file_url("file.mp4");
+  valid_video_media_info_.mutable_init_range()->set_begin(0);
+  valid_video_media_info_.mutable_init_range()->set_end(500);
+
+  ASSERT_TRUE(media_playlist_->SetMediaInfo(valid_video_media_info_));
+
+  auto prev_flag_state = FLAGS_hls_ext_x_program_date_time;
+  FLAGS_hls_ext_x_program_date_time = true;
+
+  const std::string date_time1 = timestampToString(media_playlist_->GetStartTimeStamp());
+  media_playlist_->AddSegment("file.mp4", 0, 10 * kTimeScale, 1000,
+                              1 * kMBytes);
+  const std::string date_time2 = timestampToString(media_playlist_->GetStartTimeStamp());
+  media_playlist_->AddSegment("file.mp4", 10 * kTimeScale, 10 * kTimeScale,
+                              1001000, 2 * kMBytes);
+  std::string kExpectedOutput = base::StringPrintf(
+      "#EXTM3U\n"
+      "#EXT-X-VERSION:6\n"
+      "## Generated with https://github.com/google/shaka-packager version "
+      "test\n"
+      "#EXT-X-TARGETDURATION:10\n"
+      "#EXT-X-PLAYLIST-TYPE:VOD\n"
+      "#EXT-X-MAP:URI=\"file.mp4\",BYTERANGE=\"501@0\"\n"
+      "#EXTINF:10.000,\n"
+      "#EXT-X-PROGRAM-DATE-TIME:%s\n"
+      "#EXT-X-BYTERANGE:1000000@1000\n"
+      "file.mp4\n"
+      "#EXTINF:10.000,\n"
+      "#EXT-X-PROGRAM-DATE-TIME:%s\n"
+      "#EXT-X-BYTERANGE:2000000\n"
+      "file.mp4\n"
+      "#EXT-X-ENDLIST\n",
+          date_time1.c_str(), date_time2.c_str());
+
+  const char kMemoryFilePath[] = "memory://media.m3u8";
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  FLAGS_hls_ext_x_program_date_time = prev_flag_state;
+  ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
+}
+
 // Verify that AddEncryptionInfo works (not crash).
 TEST_F(MediaPlaylistMultiSegmentTest, AddEncryptionInfo) {
   ASSERT_TRUE(media_playlist_->SetMediaInfo(valid_video_media_info_));
@@ -296,6 +353,41 @@ TEST_F(MediaPlaylistMultiSegmentTest, SetTargetDuration) {
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
   EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
+}
+
+TEST_F(MediaPlaylistMultiSegmentTest, WriteToFileWithTagExtXProgramDateTime) {
+  valid_video_media_info_.set_reference_time_scale(90000);
+  ASSERT_TRUE(media_playlist_->SetMediaInfo(valid_video_media_info_));
+
+  auto prev_flag_state = FLAGS_hls_ext_x_program_date_time;
+  FLAGS_hls_ext_x_program_date_time = true;
+
+  const std::string date_time1 = timestampToString(media_playlist_->GetStartTimeStamp());
+  media_playlist_->AddSegment("file1.ts", 0, 10 * kTimeScale, kZeroByteOffset,
+                              kMBytes);
+  const std::string date_time2 = timestampToString(media_playlist_->GetStartTimeStamp());
+  media_playlist_->AddSegment("file2.ts", 10 * kTimeScale, 30 * kTimeScale,
+                              kZeroByteOffset, 5 * kMBytes);
+  std::string kExpectedOutput = base::StringPrintf(
+      "#EXTM3U\n"
+      "#EXT-X-VERSION:6\n"
+      "## Generated with https://github.com/google/shaka-packager version "
+      "test\n"
+      "#EXT-X-TARGETDURATION:30\n"
+      "#EXT-X-PLAYLIST-TYPE:VOD\n"
+      "#EXTINF:10.000,\n"
+      "#EXT-X-PROGRAM-DATE-TIME:%s\n"
+      "file1.ts\n"
+      "#EXTINF:30.000,\n"
+      "#EXT-X-PROGRAM-DATE-TIME:%s\n"
+      "file2.ts\n"
+      "#EXT-X-ENDLIST\n",
+          date_time1.c_str(), date_time2.c_str());
+
+  const char kMemoryFilePath[] = "memory://media.m3u8";
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  FLAGS_hls_ext_x_program_date_time = prev_flag_state;
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -712,6 +804,41 @@ TEST_F(LiveMediaPlaylistTest, TimeShifted) {
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
+TEST_F(LiveMediaPlaylistTest, TimeShiftedWithTagExtXProgramDateTime) {
+  ASSERT_TRUE(media_playlist_->SetMediaInfo(valid_video_media_info_));
+
+  auto prev_flag_state = FLAGS_hls_ext_x_program_date_time;
+  FLAGS_hls_ext_x_program_date_time = true;
+
+  media_playlist_->AddSegment("file1.ts", 0, 10 * kTimeScale, kZeroByteOffset,
+                              kMBytes);
+  const std::string date_time1 = timestampToString(media_playlist_->GetStartTimeStamp());
+  media_playlist_->AddSegment("file2.ts", 10 * kTimeScale, 20 * kTimeScale,
+                              kZeroByteOffset, 2 * kMBytes);
+  const std::string date_time2 = timestampToString(media_playlist_->GetStartTimeStamp());
+  media_playlist_->AddSegment("file3.ts", 30 * kTimeScale, 20 * kTimeScale,
+                              kZeroByteOffset, 2 * kMBytes);
+  std::string kExpectedOutput = base::StringPrintf(
+      "#EXTM3U\n"
+      "#EXT-X-VERSION:6\n"
+      "## Generated with https://github.com/google/shaka-packager version "
+      "test\n"
+      "#EXT-X-TARGETDURATION:20\n"
+      "#EXT-X-MEDIA-SEQUENCE:1\n"
+      "#EXTINF:20.000,\n"
+      "#EXT-X-PROGRAM-DATE-TIME:%s\n"
+      "file2.ts\n"
+      "#EXTINF:20.000,\n"
+      "#EXT-X-PROGRAM-DATE-TIME:%s\n"
+      "file3.ts\n",
+          date_time1.c_str(), date_time2.c_str());
+
+  const char kMemoryFilePath[] = "memory://media.m3u8";
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  FLAGS_hls_ext_x_program_date_time = prev_flag_state;
+  ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
+}
+
 TEST_F(LiveMediaPlaylistTest, TimeShiftedWithEncryptionInfo) {
   ASSERT_TRUE(media_playlist_->SetMediaInfo(valid_video_media_info_));
 
@@ -849,6 +976,39 @@ TEST_F(EventMediaPlaylistTest, Basic) {
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
+TEST_F(EventMediaPlaylistTest, BasicWithTagExtXProgramDateTime) {
+  ASSERT_TRUE(media_playlist_->SetMediaInfo(valid_video_media_info_));
+
+  auto prev_flag_state = FLAGS_hls_ext_x_program_date_time;
+  FLAGS_hls_ext_x_program_date_time = true;
+
+  const std::string date_time1 = timestampToString(media_playlist_->GetStartTimeStamp());
+  media_playlist_->AddSegment("file1.ts", 0, 10 * kTimeScale, kZeroByteOffset,
+                              kMBytes);
+  const std::string date_time2 = timestampToString(media_playlist_->GetStartTimeStamp());
+  media_playlist_->AddSegment("file2.ts", 10 * kTimeScale, 20 * kTimeScale,
+                              kZeroByteOffset, 2 * kMBytes);
+  std::string kExpectedOutput = base::StringPrintf(
+      "#EXTM3U\n"
+      "#EXT-X-VERSION:6\n"
+      "## Generated with https://github.com/google/shaka-packager version "
+      "test\n"
+      "#EXT-X-TARGETDURATION:20\n"
+      "#EXT-X-PLAYLIST-TYPE:EVENT\n"
+      "#EXTINF:10.000,\n"
+      "#EXT-X-PROGRAM-DATE-TIME:%s\n"
+      "file1.ts\n"
+      "#EXTINF:20.000,\n"
+      "#EXT-X-PROGRAM-DATE-TIME:%s\n"
+      "file2.ts\n",
+          date_time1.c_str(), date_time2.c_str());
+
+  const char kMemoryFilePath[] = "memory://media.m3u8";
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  FLAGS_hls_ext_x_program_date_time = prev_flag_state;
+  ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
+}
+
 class IFrameMediaPlaylistTest : public MediaPlaylistTest {};
 
 TEST_F(IFrameMediaPlaylistTest, MediaPlaylistType) {
@@ -902,6 +1062,61 @@ TEST_F(IFrameMediaPlaylistTest, SingleSegment) {
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
   EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
+}
+
+TEST_F(IFrameMediaPlaylistTest, SingleSegmentWithTagExtXProgramDateTime) {
+  valid_video_media_info_.set_media_file_url("file.mp4");
+  valid_video_media_info_.mutable_init_range()->set_begin(0);
+  valid_video_media_info_.mutable_init_range()->set_end(500);
+  auto prev_flag_state = FLAGS_hls_ext_x_program_date_time;
+  FLAGS_hls_ext_x_program_date_time = true;
+
+  ASSERT_TRUE(media_playlist_->SetMediaInfo(valid_video_media_info_));
+  const std::string date_time1 = timestampToString(media_playlist_->GetStartTimeStamp());
+  media_playlist_->AddKeyFrame(0, 1000, 2345);
+  const std::string date_time2 = timestampToString(media_playlist_->GetStartTimeStamp());
+  media_playlist_->AddKeyFrame(2 * kTimeScale, 5000, 6345);
+  media_playlist_->AddSegment("file.mp4", 0, 10 * kTimeScale, kZeroByteOffset,
+                              kMBytes);
+  const std::string date_time3 = timestampToString(media_playlist_->GetStartTimeStamp());
+  media_playlist_->AddKeyFrame(11 * kTimeScale, kMBytes + 1000, 2345);
+  const std::string date_time4 = timestampToString(media_playlist_->GetStartTimeStamp());
+  media_playlist_->AddKeyFrame(15 * kTimeScale, kMBytes + 3345, 12345);
+  media_playlist_->AddSegment("file.mp4", 10 * kTimeScale, 10 * kTimeScale,
+                              1001000, 2 * kMBytes);
+
+  const std::string kExpectedOutput = base::StringPrintf(
+      "#EXTM3U\n"
+      "#EXT-X-VERSION:6\n"
+      "## Generated with https://github.com/google/shaka-packager version "
+      "test\n"
+      "#EXT-X-TARGETDURATION:9\n"
+      "#EXT-X-PLAYLIST-TYPE:VOD\n"
+      "#EXT-X-I-FRAMES-ONLY\n"
+      "#EXT-X-MAP:URI=\"file.mp4\",BYTERANGE=\"501@0\"\n"
+      "#EXTINF:2.000,\n"
+      "#EXT-X-PROGRAM-DATE-TIME:%s\n"
+      "#EXT-X-BYTERANGE:2345@1000\n"
+      "file.mp4\n"
+      "#EXTINF:9.000,\n"
+      "#EXT-X-PROGRAM-DATE-TIME:%s\n"
+      "#EXT-X-BYTERANGE:6345@5000\n"
+      "file.mp4\n"
+      "#EXTINF:4.000,\n"
+      "#EXT-X-PROGRAM-DATE-TIME:%s\n"
+      "#EXT-X-BYTERANGE:2345@1001000\n"
+      "file.mp4\n"
+      "#EXTINF:5.000,\n"
+      "#EXT-X-PROGRAM-DATE-TIME:%s\n"
+      "#EXT-X-BYTERANGE:12345\n"
+      "file.mp4\n"
+      "#EXT-X-ENDLIST\n",
+          date_time1.c_str(), date_time2.c_str(), date_time3.c_str(), date_time4.c_str());
+
+  const char kMemoryFilePath[] = "memory://media.m3u8";
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  FLAGS_hls_ext_x_program_date_time = prev_flag_state;
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 

--- a/packager/hls/public/hls_params.h
+++ b/packager/hls/public/hls_params.h
@@ -59,6 +59,8 @@ struct HlsParams {
   /// Custom EXT-X-MEDIA-SEQUENCE value to allow continuous media playback
   /// across packager restarts. See #691 for details.
   uint32_t media_sequence_number = 0;
+  /// Enable generation of EXT-X-PROGRAM-DATE-TIME tag.
+  bool ext_x_program_date_time = false;
 };
 
 }  // namespace shaka


### PR DESCRIPTION
…HLS playlists, with fixed UTC timezone.
Command-line switch to go on with this tag: --hls_ext_x_program_date_time.
Probably closes issue [#365 ].