### PR TITLE
Made changes in media/mp4/box_definitions.cc to fix issue812

### DIFF
--- a/packager/media/formats/mp4/box_definitions.cc
+++ b/packager/media/formats/mp4/box_definitions.cc
@@ -1059,7 +1059,12 @@ bool SampleGroupDescription::ReadWriteEntries(BoxBuffer* buffer,
 
   uint32_t count = static_cast<uint32_t>(entries->size());
   RCHECK(buffer->ReadWriteUInt32(&count));
-  RCHECK(count != 0);
+  if (buffer->Reading()) {
+    if (count == 0)
+      return true;
+  } else {
+    RCHECK(count != 0);
+  }
   entries->resize(count);
 
   for (T& entry : *entries) {


### PR DESCRIPTION
#812  Packaging fails if input content contains SampleGroupDescriptionBox with 0 entries.
Made required changes to the file -  packager/media/formats/mp4/box_definitions.cc to fix the issue.