### PR TITLE
[DASH] Template based url construction with RepresentationID.

### DIFF
--- a/packager/app/muxer_factory.cc
+++ b/packager/app/muxer_factory.cc
@@ -35,6 +35,7 @@ std::shared_ptr<Muxer> MuxerFactory::CreateMuxer(
   options.output_file_name = stream.output;
   options.segment_template = stream.segment_template;
   options.bandwidth = stream.bandwidth;
+  options.rep_id = stream.rep_id;
 
   std::shared_ptr<Muxer> muxer;
 

--- a/packager/app/stream_descriptor.cc
+++ b/packager/app/stream_descriptor.cc
@@ -35,6 +35,7 @@ enum FieldType {
   kDashRolesField,
   kDashOnlyField,
   kHlsOnlyField,
+  kRepIdField,
 };
 
 struct FieldNameToTypeMapping {
@@ -81,6 +82,7 @@ const FieldNameToTypeMapping kFieldNameTypeMappings[] = {
     {"role", kDashRolesField},
     {"dash_only", kDashOnlyField},
     {"hls_only", kHlsOnlyField},
+    {"rep_id", kRepIdField},
 };
 
 FieldType GetFieldType(const std::string& field_name) {
@@ -235,6 +237,9 @@ base::Optional<StreamDescriptor> ParseStreamDescriptor(
           return base::nullopt;
         }
         descriptor.hls_only = hls_only_value > 0;
+        break;
+      case kRepIdField:
+        descriptor.rep_id = iter->second;
         break;
       default:
         LOG(ERROR) << "Unknown field in stream descriptor (\"" << iter->first

--- a/packager/media/base/muxer.cc
+++ b/packager/media/base/muxer.cc
@@ -114,7 +114,7 @@ Status Muxer::ReinitializeMuxer(int64_t timestamp) {
     // the subclasses.
     options_.output_file_name =
         GetSegmentName(output_file_template_, timestamp, output_file_index_++,
-                       options_.bandwidth);
+                       options_.bandwidth, options_.rep_id);
   }
   return InitializeMuxer();
 }

--- a/packager/media/base/muxer_options.h
+++ b/packager/media/base/muxer_options.h
@@ -45,6 +45,10 @@ struct MuxerOptions {
   /// User-specified bit rate for the media stream. If zero, the muxer will
   /// attempt to estimate.
   uint32_t bandwidth = 0;
+
+  /// Used as Representation id for template based url construction using
+  /// $RepresentationID$.
+  std::string rep_id;
 };
 
 }  // namespace media

--- a/packager/media/base/muxer_util.h
+++ b/packager/media/base/muxer_util.h
@@ -35,7 +35,8 @@ Status ValidateSegmentTemplate(const std::string& segment_template);
 std::string GetSegmentName(const std::string& segment_template,
                            uint64_t segment_start_time,
                            uint32_t segment_index,
-                           uint32_t bandwidth);
+                           uint32_t bandwidth,
+                           std::string rep_id = "");
 
 }  // namespace media
 }  // namespace shaka

--- a/packager/media/base/muxer_util_unittest.cc
+++ b/packager/media/base/muxer_util_unittest.cc
@@ -39,7 +39,7 @@ TEST(MuxerUtilTest, ValidateSegmentTemplate) {
   EXPECT_NE(Status::OK, ValidateSegmentTemplate("foo$Number$_$Time$loo"));
 
   // $RepresentationID$ not implemented yet.
-  EXPECT_NE(Status::OK, ValidateSegmentTemplate("$RepresentationID$__$Time$"));
+  EXPECT_EQ(Status::OK, ValidateSegmentTemplate("$RepresentationID$__$Time$"));
 
   // Unknown identifier.
   EXPECT_NE(Status::OK, ValidateSegmentTemplate("$foo$$Time$"));

--- a/packager/media/event/muxer_listener_internal.cc
+++ b/packager/media/event/muxer_listener_internal.cc
@@ -200,6 +200,9 @@ void SetMediaInfoMuxerOptions(const MuxerOptions& muxer_options,
     if (!muxer_options.output_file_name.empty())
       media_info->set_init_segment_name(muxer_options.output_file_name);
     media_info->set_segment_template(muxer_options.segment_template);
+    if (!muxer_options.rep_id.empty()) {
+      media_info->set_rep_id(muxer_options.rep_id);
+    }
   }
 }
 

--- a/packager/media/formats/mp2t/ts_segmenter.cc
+++ b/packager/media/formats/mp2t/ts_segmenter.cc
@@ -176,9 +176,9 @@ Status TsSegmenter::FinalizeSegment(uint64_t start_timestamp,
   // be false.
   if (!segment_started_)
     return Status::OK;
-  std::string segment_path =
-        GetSegmentName(muxer_options_.segment_template, segment_start_timestamp_,
-                       segment_number_++, muxer_options_.bandwidth);
+  std::string segment_path = GetSegmentName(
+      muxer_options_.segment_template, segment_start_timestamp_,
+      segment_number_++, muxer_options_.bandwidth, muxer_options_.rep_id);
 
   const int64_t file_size = segment_buffer_.Size();
   std::unique_ptr<File, FileCloser> segment_file;	  

--- a/packager/media/formats/mp4/multi_segment_segmenter.cc
+++ b/packager/media/formats/mp4/multi_segment_segmenter.cc
@@ -110,9 +110,9 @@ Status MultiSegmentSegmenter::WriteSegment() {
                                              options().output_file_name);
     }
   } else {
-    file_name = GetSegmentName(options().segment_template,
-                               sidx()->earliest_presentation_time,
-                               num_segments_++, options().bandwidth);
+    file_name = GetSegmentName(
+        options().segment_template, sidx()->earliest_presentation_time,
+        num_segments_++, options().bandwidth, options().rep_id);
     file.reset(File::Open(file_name.c_str(), "w"));
     if (!file) {
       return Status(error::FILE_FAILURE,

--- a/packager/media/formats/packed_audio/packed_audio_writer.cc
+++ b/packager/media/formats/packed_audio/packed_audio_writer.cc
@@ -79,7 +79,8 @@ Status PackedAudioWriter::FinalizeSegment(size_t stream_id,
       options().segment_template.empty()
           ? options().output_file_name
           : GetSegmentName(options().segment_template, segment_timestamp,
-                           segment_number_++, options().bandwidth);
+                           segment_number_++, options().bandwidth,
+			   options().rep_id);
 
   // Save |segment_size| as it will be cleared after writing.
   const size_t segment_size = segmenter_->segment_buffer()->Size();

--- a/packager/media/formats/webm/multi_segment_segmenter.cc
+++ b/packager/media/formats/webm/multi_segment_segmenter.cc
@@ -34,7 +34,7 @@ Status MultiSegmentSegmenter::FinalizeSegment(uint64_t start_timestamp,
   if (!is_subsegment) {
     std::string segment_name =
         GetSegmentName(options().segment_template, start_timestamp,
-                       num_segment_, options().bandwidth);
+                       num_segment_, options().bandwidth, options().rep_id);
 
     // Close the file, which also does flushing, to make sure the file is
     // written before manifest is updated.
@@ -91,7 +91,7 @@ Status MultiSegmentSegmenter::NewSegment(uint64_t start_timestamp,
     temp_file_name_ =
         "memory://" + GetSegmentName(options().segment_template,
                                      start_timestamp, num_segment_,
-                                     options().bandwidth);
+                                     options().bandwidth, options().rep_id);
 
     writer_.reset(new MkvWriter);
     Status status = writer_->Open(temp_file_name_);

--- a/packager/media/formats/webvtt/webvtt_text_output_handler.cc
+++ b/packager/media/formats/webvtt/webvtt_text_output_handler.cc
@@ -90,8 +90,8 @@ Status WebVttTextOutputHandler::OnSegmentInfo(const SegmentInfo& info) {
   const uint64_t duration = info.duration;
   const uint32_t bandwidth = muxer_options_.bandwidth;
 
-  const std::string filename =
-      GetSegmentName(segment_template, start, index, bandwidth);
+  const std::string filename = GetSegmentName(segment_template, start, index,
+                                              bandwidth, muxer_options_.rep_id);
 
   // Write everything to the file before telling the manifest so that the
   // file will exist on disk.

--- a/packager/mpd/base/adaptation_set.h
+++ b/packager/mpd/base/adaptation_set.h
@@ -317,6 +317,10 @@ class AdaptationSet {
   // and HD videos in different AdaptationSets can share the same trick play
   // stream.
   std::vector<const AdaptationSet*> trick_play_references_;
+
+  // Set to true if SegmentTemplate needs to be added to AdaptationSet,
+  // instead of Representation.
+  bool include_segment_template_in_adaptation_set = false;
 };
 
 }  // namespace shaka

--- a/packager/mpd/base/media_info.proto
+++ b/packager/mpd/base/media_info.proto
@@ -184,6 +184,7 @@ message MediaInfo {
   // This value is not necessarily the same as the value passed to
   // MpdNotifier::NotifyNewSegment().
   optional float segment_duration_seconds = 12 [deprecated = true];
+  optional string rep_id = 23;
   // END LIVE only.
 
   // URL fields for the corresponding file_name fields above.

--- a/packager/mpd/base/mpd_builder.cc
+++ b/packager/mpd/base/mpd_builder.cc
@@ -441,8 +441,20 @@ void MpdBuilder::MakePathsRelativeToMpd(const std::string& mpd_path,
             MakePathRelative(media_info->init_segment_name(), mpd_dir));
       }
       if (media_info->has_segment_template()) {
-        media_info->set_segment_template_url(
-            MakePathRelative(media_info->segment_template(), mpd_dir));
+        if (media_info->has_rep_id()) {
+          if (media_info->segment_template().find("$RepresentationID") !=
+              std::string::npos) {
+            std::string temp = media_info->segment_template();
+            temp.replace(
+                media_info->segment_template().find("$RepresentationID"), 18,
+                media_info->rep_id());
+            media_info->set_segment_template_url(
+                MakePathRelative(temp, mpd_dir));
+          }
+        } else {
+          media_info->set_segment_template_url(
+              MakePathRelative(media_info->segment_template(), mpd_dir));
+        }
       }
     }
   }

--- a/packager/mpd/base/representation.h
+++ b/packager/mpd/base/representation.h
@@ -57,6 +57,7 @@ class Representation {
     kSuppressWidth = 1,
     kSuppressHeight = 2,
     kSuppressFrameRate = 4,
+    kSuppressSegmentTemplate = 8,
   };
 
   virtual ~Representation();
@@ -117,6 +118,9 @@ class Representation {
 
   /// @return Copy of <Representation>.
   xml::scoped_xml_ptr<xmlNode> GetXml();
+
+  /// @return SegmentTemplate xmlNode if live information is present.
+  xml::scoped_xml_ptr<xmlNode> GetLiveOnlyInfo();
 
   /// By calling this methods, the next time GetXml() is
   /// called, the corresponding attributes will not be set.
@@ -244,6 +248,9 @@ class Representation {
   // Segments with duration difference less than one frame duration are
   // considered to have the same duration.
   uint32_t frame_duration_ = 0;
+
+  // When set to true, adds $RepresentationID$ in SegmentTemplate.
+  bool rep_id_set = false;
 };
 
 }  // namespace shaka

--- a/packager/mpd/base/xml/xml_node.h
+++ b/packager/mpd/base/xml/xml_node.h
@@ -66,6 +66,10 @@ class XmlNode {
   /// @param id is the ID for this element.
   void SetId(uint32_t id);
 
+  /// Sets 'id=rep_id' attribute.
+  /// @param id is the ID for this element.
+  void SetIdString(std::string id);
+
   /// Set the contents of an XML element using a string.
   /// This cannot set child elements because <> will become &lt; and &rt;
   /// This should be used to set the text for the element, e.g. setting
@@ -187,6 +191,14 @@ class RepresentationXmlNode : public RepresentationBaseXmlNode {
   bool AddLiveOnlyInfo(const MediaInfo& media_info,
                        const std::list<SegmentInfo>& segment_infos,
                        uint32_t start_number);
+
+  /// @param segment_infos is a set of SegmentInfos. This method assumes that
+  ///        SegmentInfos are sorted by its start time.
+  /// @return SegmentTemplate node.
+  scoped_xml_ptr<xmlNode> GetLiveOnlyInfo(
+      const MediaInfo& media_info,
+      const std::list<SegmentInfo>& segment_infos,
+      uint32_t start_number);
 
  private:
   // Add AudioChannelConfiguration element. Note that it is a required element

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -316,7 +316,8 @@ Status ValidateParams(const PackagingParams& packaging_params,
     }
 
     if (!descriptor.output.empty()) {
-      if (outputs.find(descriptor.output) != outputs.end()) {
+      if (descriptor.output.find("$RepresentationID$") == std::string::npos &&
+          outputs.find(descriptor.output) != outputs.end()) {
         return Status(
             error::INVALID_ARGUMENT,
             "Seeing duplicated outputs '" + descriptor.output +
@@ -325,8 +326,10 @@ Status ValidateParams(const PackagingParams& packaging_params,
       outputs.insert(descriptor.output);
     }
     if (!descriptor.segment_template.empty()) {
-      if (segment_templates.find(descriptor.segment_template) !=
-          segment_templates.end()) {
+      if (descriptor.segment_template.find("$RepresentationID$") ==
+              std::string::npos &&
+          segment_templates.find(descriptor.segment_template) !=
+              segment_templates.end()) {
         return Status(error::INVALID_ARGUMENT,
                       "Seeing duplicated segment templates '" +
                           descriptor.segment_template +

--- a/packager/packager.h
+++ b/packager/packager.h
@@ -133,6 +133,8 @@ struct StreamDescriptor {
   bool dash_only = false;
   /// Set to true to indicate that the stream is for hls only.
   bool hls_only = false;
+
+  std::string rep_id;
 };
 
 class SHAKA_EXPORT Packager {
@@ -144,9 +146,8 @@ class SHAKA_EXPORT Packager {
   /// @param packaging_params contains the packaging parameters.
   /// @param stream_descriptors a list of stream descriptors.
   /// @return OK on success, an appropriate error code on failure.
-  Status Initialize(
-      const PackagingParams& packaging_params,
-      const std::vector<StreamDescriptor>& stream_descriptors);
+  Status Initialize(const PackagingParams& packaging_params,
+                    const std::vector<StreamDescriptor>& stream_descriptors);
 
   /// Run the pipeline to completion (or failed / been cancelled). Note
   /// that it blocks until completion.


### PR DESCRIPTION
Trying to implement template based url construction that uses $RepresentationID$. This will add SegmentTemplate below adaptationSet instead of every Representation.
I have added a new stream descriptor field called rep_id that takes in the representation id. 

Example:
```
../packager \                                                                  
  'in=S-1024x576.mp4,stream=video,init_segment=$RepresentationID$/init.mp4,segment_template=$RepresentationID$/$Number$.m4s,rep_id=RES-1024x576' \
  'in=S-1280x720.mp4,stream=video,init_segment=$RepresentationID$/init.mp4,segment_template=$RepresentationID$/$Number$.m4s,rep_id=RES-1280x720' \
  --mpd_output test_mpd.mpd
```

and following is the generated mpd: 

```
<?xml version="1.0" encoding="UTF-8"?>                                          
<!--Generated with https://github.com/google/shaka-packager version 5b9fd409a5-debug-->
<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="PT2S" type="dynamic" publishTime="2020-09-26T00:16:44Z" availabilityStartTime="2020-09-26T00:16:43Z" minimumUpdatePeriod="PT5S" timeShiftBufferDepth="PT1800S">
  <Period id="0" start="PT0S">                                                  
    <AdaptationSet id="0" contentType="video" maxWidth="1280" maxHeight="720" maxFrameRate="96/4" segmentAlignment="true" par="16:9">
      <SegmentTemplate timescale="96" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="1">
        <SegmentTimeline>                                                      
          <S t="0" d="576" r="7"/>                                              
          <S t="4608" d="404"/>                                                
        </SegmentTimeline>                                                      
      </SegmentTemplate>                                                        
      <Representation id="RES-1024x576" bandwidth="212490" codecs="avc1.4d401f" mimeType="video/mp4" sar="1:1" width="1024" height="576" frameRate="96/192"/>
      <Representation id="RES-1280x720" bandwidth="2942370" codecs="avc1.4d401f" mimeType="video/mp4" sar="1:1" width="1280" height="720" frameRate="96/4"/>
    </AdaptationSet>                                                            
  </Period>                                                                    
</MPD> 
```

This is similar to MP4Box where ids are specified along with tracks: 
Example:
```
mp4box -dash 12000 -frag 12000 -mem-frags -rap -profile dashavc264:live ^
  -profile-ext "urn:hbbtv:dash:profile:isoff-live:2012" ^
  -mpd-title "" -mpd-info-url "" ^
  -bs-switching no -sample-groups-traf -single-traf -subsegs-per-sidx 1 ^
  -segment-name "$RepresentationID$_$Number$$Init=i$" -segment-timeline ^
  -out "manifest_orig.mpd" ^
  "temp-360p.mp4#trackID=1:id=360p" ^
  "temp-720p.mp4#trackID=1:id=720p" ^
  "temp-1080p.mp4#trackID=1:id=1080p" ^
  "temp-128k.mp4#trackID=1:id=128k"
```

@kqyang please let me know what you think about this approach.