### PR TITLE
pssh-box python 3 errors fix

### DIFF
--- a/packager/tools/pssh/pssh-box.py
+++ b/packager/tools/pssh/pssh-box.py
@@ -124,7 +124,7 @@ class Pssh(object):
           lines.extend(['      ' + x for x in extra])
         # pylint: disable=broad-except
         except Exception as e:
-          lines.append('      ERROR: ' + e.message)
+          lines.append('      ERROR: ' + str(e))
       else:
         lines.extend([
             '    Raw Data (base64):',
@@ -148,7 +148,7 @@ def _create_bin_int(value):
 
 def _create_uuid(data):
   """Creates a human readable UUID string from the given binary string."""
-  ret = base64.b16encode(data).lower()
+  ret = base64.b16encode(data).decode().lower()
   return (ret[:8] + '-' + ret[8:12] + '-' + ret[12:16] + '-' + ret[16:20] +
           '-' + ret[20:])
 
@@ -180,7 +180,7 @@ def _parse_widevine_data(data):
   if wv.HasField('provider'):
     ret.append('Provider: ' + wv.provider)
   if wv.HasField('content_id'):
-    ret.append('Content ID: ' + base64.b16encode(wv.content_id))
+    ret.append('Content ID: ' + base64.b16encode(wv.content_id).decode())
   if wv.HasField('policy'):
     ret.append('Policy: ' + wv.policy)
   if wv.HasField('crypto_period_index'):

--- a/packager/tools/pssh/pssh-box.py
+++ b/packager/tools/pssh/pssh-box.py
@@ -141,9 +141,9 @@ def _split_list_on(elems, sep):
 
 
 def _create_bin_int(value):
-  """Creates a 4-byte binary string from the given integer."""
+  """Creates a binary string as 4-byte array from the given integer."""
   return (chr(value >> 24) + chr((value >> 16) & 0xff) +
-          chr((value >> 8) & 0xff) + chr(value & 0xff))
+          chr((value >> 8) & 0xff) + chr(value & 0xff)).encode()
 
 
 def _create_uuid(data):
@@ -423,11 +423,11 @@ def main(all_args):
     for box in boxes:
       print(box.human_string())
   else:
-    box_data = ''.join([x.binary_string() for x in boxes])
+    box_data = b''.join([x.binary_string() for x in boxes])
     if output_format == 'hex':
-      print(base64.b16encode(box_data))
+      print(base64.b16encode(box_data).decode())
     else:
-      print(base64.b64encode(box_data))
+      print(base64.b64encode(box_data).decode())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I'm not a fluent python developer but I put some effort to fix python 3 errors and make this tool still usable under python 2.

I tried all sample options from https://github.com/google/shaka-packager/blob/master/packager/tools/pssh/README.md and they work with python 2.7 and 3.8.6

e.g.
```
$ python2 out/Debug/pssh-box.py --widevine-system-id --content-id 1231897231 --hex
000000277073736800000000EDEF8BA979D64ACEA3C827DCD51D21ED0000000722051231897231

$ python7 out/Debug/pssh-box.py --widevine-system-id --content-id 1231897231 --hex
000000277073736800000000EDEF8BA979D64ACEA3C827DCD51D21ED0000000722051231897231
```

Fixes #833 