### PR TITLE
Fix wrong _create_bin_int implementation in pssh-box.py

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -45,3 +45,4 @@ Sergio Ammirata <sergio@ammirata.net>
 Thomas Inskip <tinskip@google.com>
 Tim Lansen <tim.lansen@gmail.com>
 Weiguo Shao <weiguo.shao@dolby.com>
+Qingquan Wang <wangqq1103@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -38,6 +38,7 @@ Kongqun Yang <kqyang@google.com>
 Leandro Moreira <leandro.ribeiro.moreira@gmail.com>
 Leo Law <leoltlaw.gh@gmail.com>
 Piotr Srebrny <srebrny.piotr@gmail.com>
+Qingquan Wang <wangqq1103@gmail.com>
 Richard Eklycke <richard@eklycke.se>
 Rintaro Kuroiwa <rkuroiwa@google.com>
 Sanil Raut <sr1990003@gmail.com>
@@ -45,4 +46,3 @@ Sergio Ammirata <sergio@ammirata.net>
 Thomas Inskip <tinskip@google.com>
 Tim Lansen <tim.lansen@gmail.com>
 Weiguo Shao <weiguo.shao@dolby.com>
-Qingquan Wang <wangqq1103@gmail.com>

--- a/packager/tools/pssh/pssh-box.py
+++ b/packager/tools/pssh/pssh-box.py
@@ -142,8 +142,7 @@ def _split_list_on(elems, sep):
 
 def _create_bin_int(value):
   """Creates a binary string as 4-byte array from the given integer."""
-  return (chr(value >> 24) + chr((value >> 16) & 0xff) +
-          chr((value >> 8) & 0xff) + chr(value & 0xff)).encode()
+  return struct.pack('>i', value)
 
 
 def _create_uuid(data):


### PR DESCRIPTION
The implementation is wrong for some value, which leads to wrong pssh box generation from pssh data.

Example: value = 132, below is the result in python3 shell. (python 3.6.9)

```
>>> value=132
>>> (chr(value >> 24) + chr((value >> 16) & 0xff) + chr((value >> 8) & 0xff) + chr(value & 0xff)).encode()
b'\x00\x00\x00\xc2\x84'
>>> import struct
>>> struct.pack('>i', value)
b'\x00\x00\x00\x84'
```
The previous implementation outputs 5 bytes which is wrong.