### PR TITLE
[DASH] - encryption validation only for non-text streams

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -645,9 +645,9 @@ Status CreateAudioVideoJobs(
       if (!is_text) {
         handlers.emplace_back(std::make_shared<ChunkingHandler>(
             packaging_params.chunking_params));
+        handlers.emplace_back(CreateEncryptionHandler(packaging_params,
+            stream, encryption_key_source));
       }
-      handlers.emplace_back(CreateEncryptionHandler(packaging_params, stream,
-                                                    encryption_key_source));
 
       replicator = std::make_shared<Replicator>();
       handlers.emplace_back(replicator);

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -645,8 +645,8 @@ Status CreateAudioVideoJobs(
       if (!is_text) {
         handlers.emplace_back(std::make_shared<ChunkingHandler>(
             packaging_params.chunking_params));
-        handlers.emplace_back(CreateEncryptionHandler(packaging_params,
-            stream, encryption_key_source));
+        handlers.emplace_back(CreateEncryptionHandler(packaging_params, stream,
+                                                      encryption_key_source));
       }
 
       replicator = std::make_shared<Replicator>();


### PR DESCRIPTION
Fixes https://github.com/google/shaka-packager/issues/883

Example: 
Input:
./packager 'in=/YR_12025_jb_2CH_401160_375.mp4,stream=video,init_segment=/YR_12025_jb_2CH_401160_375/init.m4v,segment_template=/420776_cenc_dash/YR_12025_jb_2CH_401160_375/seg_$Number$.m4s,drm_label=sd' 'in=/YR_12025_jb_2CH_401160_2100.mp4,stream=video,init_segment=/YR_12025_jb_2CH_401160_2100/init.m4v,segment_template=/YR_12025_jb_2CH_401160_2100/seg_$Number$.m4s,drm_label=hd' 'in=/YR_12025_jb_2CH_en-US_401160_3_aac_128.mp4,stream=audio,init_segment=/YR_12025_jb_2CH_en-US_401160_3_aac_128/init.m4v,segment_template=/YR_12025_jb_2CH_en-US_401160_3_aac_128/seg_$Number$.m4s,lang=en,drm_label=audio' 'in=/en/en.vtt,stream=text,init_segment=/en/vtt_init.m4v,language=en,segment_template=/en/seg_$Number$.m4s' --clear_lead 0 --segment_duration 6 --fragment_duration 6 --generate_static_live_mpd --mpd_output /stream.mpd --enable_raw_key_encryption --keys label=audio:key_id=82..:key=e4...,label=sd:key_id=82..:key=e4..,label=hd:key_id=82...:key=e4... --pssh 000...something..0

Output: 
packaging finishes successfully with expected output where non-text streams have DRM and text stream without DRM. 
If captions/text stream needs DRM , it should be passed the `drm_label` and `key` and that produces the right output as well. 
