### PR TITLE
WEBVTT - support center and middle text alignment

### DIFF
--- a/packager/media/formats/webvtt/webvtt_parser.cc
+++ b/packager/media/formats/webvtt/webvtt_parser.cc
@@ -176,7 +176,7 @@ void ParseSettings(const std::string& id,
   } else if (id == "align") {
     if (value == "start") {
       settings->text_alignment = TextAlignment::kStart;
-    } else if (value == "center") {
+    } else if (value == "center" || value == "middle") {
       settings->text_alignment = TextAlignment::kCenter;
     } else if (value == "end") {
       settings->text_alignment = TextAlignment::kEnd;


### PR DESCRIPTION
Fixes: https://github.com/google/shaka-packager/issues/882

```
$ packager 'in=SampleVideo_1280x720_30mb.mp4,stream=video,init_segment=/tmp/SampleVideo_1280x720_30mb/init.m4v,segment_template=/tmp/SampleVideo_1280x720_30mb/seg_$Number$.m4s' 
'in=SampleVideo_1280x720_30mb.mp4,stream=audio,init_segment=/tmp/SampleVideo_1280x720_30mb-audio/init.m4v,segment_template=/tmp/SampleVideo_1280x720_30mb-audio/seg_$Number$.m4s,lang=en' 
'in=SampleVideo_1280x720-web.vtt,stream=text,init_segment=/tmp/SampleVideo_1280x720_30mb-vtt/vtt_init.m4v,language=en,segment_template=/tmp/SampleVideo_1280x720_30mb-vtt/seg_$Number$.m4s' 
--clear_lead 0 --segment_duration 6 --fragment_duration 6 --generate_static_live_mpd 
--mpd_output /tmp/SampleVideo_1280x720_30mb/stream.mpd
```