### PR TITLE
Ensure PCR reserved bits are set when writing Adaptation Field

### DIFF
--- a/packager/media/formats/mp2t/ts_packet_writer_util.cc
+++ b/packager/media/formats/mp2t/ts_packet_writer_util.cc
@@ -97,7 +97,7 @@ void WriteAdaptationField(bool has_pcr,
     const uint32_t most_significant_32bits_pcr =
         static_cast<uint32_t>(pcr_base >> 1);
     const uint16_t pcr_last_bit_reserved_and_pcr_extension =
-        ((pcr_base & 1) << 15);
+        ((pcr_base & 1) << 15) | 0x7e00;  // Set the 6 reserved bits to '1'
     writer->AppendInt(most_significant_32bits_pcr);
     writer->AppendInt(pcr_last_bit_reserved_and_pcr_extension);
     remaining_bytes -= kPcrFieldsSize;


### PR DESCRIPTION
This is a PR to address the issue reported in #893 

The PCR value inside the TS Packet's Adaptation Field (where present) should be represented as:

program_clock_reference_base (33 bits)
reserved (6 bits)
program_clock_reference_extension (9 bits)

```
(Bit Positions)
.... ...4 .... .... .3.. .... ...2 .... .... .1.. .... ....
7654 3210 9876 5432 1098 7654 3210 9876 5432 1098 7654 3210
BBBB BBBB BBBB BBBB BBBB BBBB BBBB BBBB Brrr rrrE EEEE EEEE
----- most_significant_32bits_pcr -----|pcr_last_bit_reserved_and_pcr_extension
            (uint32_t)                         (uint16_t)

B = Base, r = reserved, E = Extension
```

The reserved bits should always be set to '1' per ISO 13818-1 therefore OR'ing a value of 0x7e00 is required to set these reserved bits imho.

Tony