### PR TITLE
Change to DEPS to potentially run on linux ARM 64

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -100,7 +100,7 @@ hooks = [
     'name': 'sysroot',
     'pattern': '.',
     'action': ['python', 'src/packager/build/linux/sysroot_scripts/install-sysroot.py',
-               '--running-as-hook'],
+               '--arch', 'arm64'],
   },
   {
     # Update the Mac toolchain if necessary.


### PR DESCRIPTION
Running gclient on linux AWS arm64 architecture produced an error related to an unexpected architecture name. Run linux cmd uname -m
Change can potentially fix issue on some systems