### PR TITLE
Update build_instructions.md

### DIFF
--- a/docs/source/build_instructions.md
+++ b/docs/source/build_instructions.md
@@ -185,7 +185,8 @@ Also, unlike Linux / Mac, 32-bit is chosen by default even if the system is
 configured to `out/%CONFIGURATION%_x64`, i.e.:
 
 ```shell
-$ GYP_DEFINES='target_arch=x64' gclient runhooks
+$ SET GYP_DEFINES='target_arch=x64' 
+$ gclient runhooks
 $ ninja -C out/Release_x64
 ```
 


### PR DESCRIPTION
For windows running `GYP_DEFINES='target_arch=X64'` shows an error GYP_DEFINES is not recognized as an internal or external command.
the actual command is to set the value of GYP_DEFINES. so it should be `SET GYP_DEFINES='target_arch=X64'` After browsing through all the issues I found that docs were wrong so updating it.