### PR TITLE
Fix MSVS 2019 builds

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -74,7 +74,7 @@ deps = {
     Var("chromium_git") + "/chromium/src/tools/clang@723b25997f0aab45fe1776a0f74a14782e350f8f",  #513983
 
   "src/packager/tools/gyp":
-    Var("chromium_git") + "/external/gyp@e7079f0e0e14108ab0dba58728ff219637458563",
+    Var("chromium_git") + "/external/gyp@caa60026e223fc501e8b337fd5086ece4028b1c6",
 
   "src/packager/tools/valgrind":
     Var("chromium_git") + "/chromium/deps/valgrind@3a97aa8142b6e63f16789b22daafb42d202f91dc",

--- a/DEPS
+++ b/DEPS
@@ -111,6 +111,8 @@ hooks = [
   {
     # Pull clang if needed or requested via GYP_DEFINES (GYP_DEFINES="clang=1").
     "name": "clang",
+    # Skip clang updates on Windows, where we don't use clang.
+    "condition": "not checkout_win",
     "pattern": ".",
     "action": ["python", "src/packager/tools/clang/scripts/update.py", "--if-needed"],
   },

--- a/docs/source/build_instructions.md
+++ b/docs/source/build_instructions.md
@@ -33,7 +33,7 @@ Note that `Git` must be v1.7.5 or above.
 
 ## Windows system requirements
 
-* Visual Studio 2015 Update 3, see below (no other version is supported).
+* Visual Studio 2015 Update 3, 2017, or 2019. (See below.)
 * Windows 7 or newer.
 
 Install Visual Studio 2015 Update 3 or later - Community Edition should work if
@@ -42,6 +42,14 @@ its license is appropriate for you. Use the Custom Install option and select:
 - Visual C++, which will select three sub-categories including MFC
 - Universal Windows Apps Development Tools > Tools (1.4.1) and Windows 10 SDK
   (10.0.14393)
+
+If using VS 2017 or VS 2019, you must set the following environment variables,
+with versions and paths adjusted to match your actual system:
+
+```shell
+GYP_MSVS_VERSION="2019"
+GYP_MSVS_OVERRIDE_PATH="C:/Program Files (x86)/Microsoft Visual Studio/2019/Community"
+```
 
 ## Install `depot_tools`
 

--- a/packager/media/chunking/cue_alignment_handler.h
+++ b/packager/media/chunking/cue_alignment_handler.h
@@ -7,6 +7,7 @@
 #ifndef PACKAGER_MEDIA_CHUNKING_CUE_ALIGNMENT_HANDLER_
 #define PACKAGER_MEDIA_CHUNKING_CUE_ALIGNMENT_HANDLER_
 
+#include <deque>
 #include <list>
 
 #include "packager/media/base/media_handler.h"
@@ -73,7 +74,7 @@ class CueAlignmentHandler : public MediaHandler {
   Status RunThroughSamples(StreamState* stream);
 
   SyncPointQueue* const sync_points_ = nullptr;
-  std::vector<StreamState> stream_states_;
+  std::deque<StreamState> stream_states_;
 
   // A common hint used by all streams. When a new cue is given to all streams,
   // the hint will be updated. The hint will always be larger than any cue. The


### PR DESCRIPTION
Summary of changes:

 - In order to use MSVS 2019, gyp must be upgraded.  The old version didn't recognize MSVS 2019, but the newer version does.
 - Skip clang downloads on Windows.  The older clang download tools don't recognize the MSVS 2019 environment.  We aren't using clang for a Windows build anyway, so just skip this hook when running gclient sync.
 - Because a StreamState object contains a unique_ptr, it is not copyable.  A vector of StreamStates, therefore, causes a compile error on resize or push_back, both of which invoke the copy constructor.
I don't know why MSVS complains, but clang does not. To fix this, I'm changing vector<StreamState> into deque<StreamState>.
 - The build instructions have been updated with necessary environment variables for newer MSVS versions.

At this point static_library builds are working in MSVS 2019.  shared_library builds are still not working.

Closes #867 (MSVS 2019)
Issue #318 (progress toward shared_library support on Windows)
Issue #336 (progress toward replacing Travis & Appveyor with GitHub Actions, which uses MSVS 2019)
b/190743862 (internal; tracking replacement of Travis)