### PR TITLE
Fix Windows shared_library builds

### DIFF
--- a/packager/common.gypi
+++ b/packager/common.gypi
@@ -52,6 +52,8 @@
                  # the current code page. It typically happens when compiling
                  # the code in CJK environment if there is non-ASCII characters
                  # in the file.
+          4251,  # Warnings about private std::string in Status in a shared
+                 # library config on Windows.
         ],
       }, {
         # We do not have control over non-shaka code. Disable some warnings to

--- a/packager/file/file.gyp
+++ b/packager/file/file.gyp
@@ -43,6 +43,14 @@
         '../third_party/curl/curl.gyp:libcurl',
         '../version/version.gyp:version',
       ],
+      'conditions': [
+        ['libpackager_type == "shared_library"', {
+          'defines': [
+            'SHARED_LIBRARY_BUILD',
+            'SHAKA_IMPLEMENTATION',
+          ],
+        }],
+      ],
     },
     {
       'target_name': 'file_unittest',

--- a/packager/file/file.h
+++ b/packager/file/file.h
@@ -13,6 +13,7 @@
 
 #include "packager/base/macros.h"
 #include "packager/file/public/buffer_callback_params.h"
+#include "packager/status.h"
 
 namespace shaka {
 
@@ -24,7 +25,7 @@ extern const char* kHttpFilePrefix;
 const int64_t kWholeFile = -1;
 
 /// Define an abstract file interface.
-class File {
+class SHAKA_EXPORT File {
  public:
   /// Open the specified file.
   /// This is a file factory method, it opens a proper file automatically

--- a/packager/packager.gyp
+++ b/packager/packager.gyp
@@ -100,12 +100,16 @@
       ],
       'dependencies': [
         'base/base.gyp:base',
-        'file/file.gyp:file',
         'libpackager',
         'third_party/gflags/gflags.gyp:gflags',
         'tools/license_notice.gyp:license_notice',
       ],
       'conditions': [
+        ['libpackager_type == "shared_library"', {
+          'defines': [
+            'SHARED_LIBRARY_BUILD',
+          ],
+        }],
         ['profiling==1', {
           'dependencies': [
             'base/allocator/allocator.gyp:allocator',
@@ -134,6 +138,13 @@
       'type': '<(gtest_target_type)',
       'sources': [
         'packager_test.cc',
+      ],
+      'conditions': [
+        ['libpackager_type == "shared_library"', {
+          'defines': [
+            'SHARED_LIBRARY_BUILD',
+          ],
+        }],
       ],
       'dependencies': [
         'libpackager',


### PR DESCRIPTION
To make shared_library builds work on Windows with MSVS 2019, this
commit:
 - Silences a useless warning about a private member in dll-exported
   Status class.
 - Exports the File class used by packager.exe
 - Removes the explicit File dependency in packager.exe in favor of
   libpackager, now that File is exported
 - Add missing defines in packager.exe and packager_test.exe that
   instruct the linker to import Status and File from the library

Closes #318 (shared_library builds on Windows)
Issue #336 (progress toward GitHub Actions workflow to replace Travis
  and Appveyor, where we need to build and test shared_library on all
  platforms)
b/190743862 (internal; tracking replacement of Travis)