### PR TITLE
Fix shared library test runs on Windows

### DIFF
--- a/packager/common.gypi
+++ b/packager/common.gypi
@@ -13,13 +13,29 @@
       # musl is a lightweight C standard library used in Alpine Linux.
       'musl%': 0,
     },
+
     'shaka_code%': '<(shaka_code)',
     'musl%': '<(musl)',
     'libpackager_type%': 'static_library',
+
     'conditions': [
       ['shaka_code==1', {
         # This enable warnings and warnings-as-errors.
         'chromium_code': 1,
+      }],
+      # These are some Chromium build settings that are normally keyed off of
+      # component=="shared_library".  We don't use component=="shared_library"
+      # because it would result in a shared lib for every single component, but
+      # we still need these settings for a shared library build of libpackager
+      # on Windows.
+      ['libpackager_type=="shared_library"', {
+        # Make sure we use a dynamic CRT to avoid issues with std::string in
+        # the library API on Windows.
+        'win_release_RuntimeLibrary': '2', # 2 = /MD (nondebug DLL)
+        'win_debug_RuntimeLibrary': '3',   # 3 = /MDd (debug DLL)
+        # Skip the Windows allocator shim on Windows.  Using this with a shared
+        # library results in build errors.
+        'win_use_allocator_shim': 0,
       }],
     ],
   },


### PR DESCRIPTION
Shared library builds worked, but failed tests because they were made
with the wrong CRT linker settings.  Strings allocated within the
library could not be freed outside the library because the dynamic CRT
was not used.

This sets necessary gyp variables to link with a dynamic CRT on
Windows, thereby fixing tests running in shared library mode that
otherwise hung in a GitHub Actions environment.

Related to #318 (shared_library builds on Windows)

Issue #336 (progress toward GitHub Actions workflow to replace Travis
  and Appveyor, where we need to build and test shared_library on all
  platforms)

b/190743862 (internal; tracking replacement of Travis)