### PR TITLE
Fix libpackager_type variable undefined by default

### DIFF
--- a/packager/common.gypi
+++ b/packager/common.gypi
@@ -12,11 +12,12 @@
       'shaka_code%': 0,
       # musl is a lightweight C standard library used in Alpine Linux.
       'musl%': 0,
+      'libpackager_type%': 'static_library',
     },
 
     'shaka_code%': '<(shaka_code)',
     'musl%': '<(musl)',
-    'libpackager_type%': 'static_library',
+    'libpackager_type%': '<(libpackager_type)',
 
     'conditions': [
       ['shaka_code==1', {


### PR DESCRIPTION
In e2efb5d4, I fixed shared_library builds on Windows, but I
introduced another issue in which the libpackager_type variable was
not correctly defined by default.  This meant that the build only
worked with this variable explicitly-defined in GYP_DEFINES when
gclient sync was run.

This fixes the default definition so that libpackager_type does not
need to be defined explicity.

Related to #318 (shared_library builds on Windows)

Issue #336 (progress toward GitHub Actions workflow to replace Travis
  and Appveyor, where we need to build and test shared_library on all
  platforms)

b/190743862 (internal; tracking replacement of Travis)

Change-Id: If353e1d3c312ab0c568d4d4d2b789e922d7216e1