### PR TITLE
Insert EXT-X-DISCONTINUITY when decoder config parameters change

### DIFF
--- a/packager/hls/base/hls_notifier.h
+++ b/packager/hls/base/hls_notifier.h
@@ -81,6 +81,9 @@ class HlsNotifier {
   /// @return true on success, false otherwise.
   virtual bool NotifyCueEvent(uint32_t stream_id, int64_t timestamp) = 0;
 
+  /// Called when the decoder config parameters have changed.
+  virtual void NotifyDecoderConfigChanged(uint32_t stream_id) = 0;
+
   /// @param stream_id is the value set by NotifyNewStream().
   /// @param key_id is the key ID for the stream.
   /// @param system_id is the DRM system ID in e.g. PSSH boxes. For example this

--- a/packager/hls/base/media_playlist.cc
+++ b/packager/hls/base/media_playlist.cc
@@ -469,6 +469,10 @@ void MediaPlaylist::AddPlacementOpportunity() {
   entries_.emplace_back(new PlacementOpportunityEntry());
 }
 
+void MediaPlaylist::AddDiscontinuity() {
+  entries_.emplace_back(new DiscontinuityEntry());
+}
+
 bool MediaPlaylist::WriteToFile(const std::string& file_path) {
   if (!target_duration_set_) {
     SetTargetDuration(ceil(GetLongestSegmentDuration()));

--- a/packager/hls/base/media_playlist.cc
+++ b/packager/hls/base/media_playlist.cc
@@ -470,6 +470,12 @@ void MediaPlaylist::AddPlacementOpportunity() {
 }
 
 void MediaPlaylist::AddDiscontinuity() {
+  // Make sure that discontinuities are not repeated
+  if(!entries_.empty() &&
+      entries_.back()->type() == HlsEntry::EntryType::kExtDiscontinuity) {
+    return;
+  }
+  
   entries_.emplace_back(new DiscontinuityEntry());
 }
 

--- a/packager/hls/base/media_playlist.h
+++ b/packager/hls/base/media_playlist.h
@@ -150,6 +150,9 @@ class MediaPlaylist {
   /// https://support.google.com/dfp_premium/answer/7295798?hl=en.
   virtual void AddPlacementOpportunity();
 
+  /// Add #EXT-X-DISCONTINUITY.
+  virtual void AddDiscontinuity();
+
   /// Write the playlist to |file_path|.
   /// This does not close the file.
   /// If target duration is not set explicitly, this will try to find the target

--- a/packager/hls/base/simple_hls_notifier.cc
+++ b/packager/hls/base/simple_hls_notifier.cc
@@ -435,6 +435,17 @@ bool SimpleHlsNotifier::NotifyCueEvent(uint32_t stream_id, int64_t timestamp) {
   return true;
 }
 
+void SimpleHlsNotifier::NotifyDecoderConfigChanged(uint32_t stream_id) {
+  base::AutoLock auto_lock(lock_);
+  auto stream_iterator = stream_map_.find(stream_id);
+  if (stream_iterator == stream_map_.end()) {
+    LOG(ERROR) << "Cannot find stream with ID: " << stream_id;
+    return;
+  }
+  auto& media_playlist = stream_iterator->second->media_playlist;
+  media_playlist->AddDiscontinuity();
+}
+
 bool SimpleHlsNotifier::NotifyEncryptionUpdate(
     uint32_t stream_id,
     const std::vector<uint8_t>& key_id,

--- a/packager/hls/base/simple_hls_notifier.h
+++ b/packager/hls/base/simple_hls_notifier.h
@@ -62,6 +62,7 @@ class SimpleHlsNotifier : public HlsNotifier {
                       uint64_t start_byte_offset,
                       uint64_t size) override;
   bool NotifyCueEvent(uint32_t container_id, int64_t timestamp) override;
+  void NotifyDecoderConfigChanged(uint32_t stream_id) override;
   bool NotifyEncryptionUpdate(
       uint32_t stream_id,
       const std::vector<uint8_t>& key_id,

--- a/packager/media/base/media_handler.cc
+++ b/packager/media/base/media_handler.cc
@@ -137,5 +137,15 @@ Status MediaHandler::NotifyDecoderConfigChanged(size_t output_stream_index) {
   return handler_it->second.first->OnDecoderConfigChanged(handler_it->second.second);
 }
 
+Status MediaHandler::NotifyAllDecoderConfigChanged() {
+   for (const auto& pair : output_handlers_) {
+    Status status = pair.second.first->OnDecoderConfigChanged(pair.second.second);
+    if (!status.ok()) {
+      return status;
+    }
+  }
+  return Status::OK;
+}
+
 }  // namespace media
 }  // namespace shaka

--- a/packager/media/base/media_handler.cc
+++ b/packager/media/base/media_handler.cc
@@ -87,6 +87,11 @@ Status MediaHandler::OnFlushRequest(size_t input_stream_index) {
   return FlushDownstream(output_stream_index);
 }
 
+void MediaHandler::OnDecoderConfigChanged() {
+  // Forward the event to all downstream handlers.
+  NotifyDecoderConfigChanged();
+}
+
 bool MediaHandler::ValidateOutputStreamIndex(size_t stream_index) const {
   return stream_index < num_input_streams_;
 }
@@ -120,5 +125,12 @@ Status MediaHandler::FlushAllDownstreams() {
   }
   return Status::OK;
 }
+
+void MediaHandler::NotifyDecoderConfigChanged() {
+  for (const auto& pair : output_handlers_) {
+    pair.second.first->OnDecoderConfigChanged();
+  }
+}
+
 }  // namespace media
 }  // namespace shaka

--- a/packager/media/base/media_handler.h
+++ b/packager/media/base/media_handler.h
@@ -189,7 +189,7 @@ class MediaHandler {
   virtual Status OnFlushRequest(size_t input_stream_index);
 
   /// Event handler for decoder config changes.
-  virtual void OnDecoderConfigChanged();
+  virtual Status OnDecoderConfigChanged(size_t input_stream_index);
 
   /// Validate if the stream at the specified index actually exists.
   virtual bool ValidateOutputStreamIndex(size_t stream_index) const;
@@ -252,8 +252,8 @@ class MediaHandler {
   /// Flush all connected downstream handlers.
   Status FlushAllDownstreams();
 
-  /// Notifies all connected downstream handlers of a decoder config change.
-  void NotifyDecoderConfigChanged();
+  /// Notify the downstream handler of a decoder config change.
+  Status NotifyDecoderConfigChanged(size_t output_stream_index);
 
   bool initialized() { return initialized_; }
   size_t num_input_streams() const { return num_input_streams_; }

--- a/packager/media/base/media_handler.h
+++ b/packager/media/base/media_handler.h
@@ -188,6 +188,9 @@ class MediaHandler {
   /// Event handler for flush request at the specific input stream index.
   virtual Status OnFlushRequest(size_t input_stream_index);
 
+  /// Event handler for decoder config changes.
+  virtual void OnDecoderConfigChanged();
+
   /// Validate if the stream at the specified index actually exists.
   virtual bool ValidateOutputStreamIndex(size_t stream_index) const;
 
@@ -248,6 +251,9 @@ class MediaHandler {
 
   /// Flush all connected downstream handlers.
   Status FlushAllDownstreams();
+
+  /// Notifies all connected downstream handlers of a decoder config change.
+  void NotifyDecoderConfigChanged();
 
   bool initialized() { return initialized_; }
   size_t num_input_streams() const { return num_input_streams_; }

--- a/packager/media/base/media_handler.h
+++ b/packager/media/base/media_handler.h
@@ -255,6 +255,9 @@ class MediaHandler {
   /// Notify the downstream handler of a decoder config change.
   Status NotifyDecoderConfigChanged(size_t output_stream_index);
 
+  // Notify all downstream handlers of a decoder config change.
+  Status NotifyAllDecoderConfigChanged();
+
   bool initialized() { return initialized_; }
   size_t num_input_streams() const { return num_input_streams_; }
   size_t next_output_stream_index() const { return next_output_stream_index_; }

--- a/packager/media/base/media_parser.h
+++ b/packager/media/base/media_parser.h
@@ -52,6 +52,9 @@ class MediaParser {
                               std::shared_ptr<TextSample> text_sample)>
       NewTextSampleCB;
 
+  /// Called when the decoder config parameters have changed.
+  typedef base::Callback<void()> DecoderConfigChangedCB;
+
   /// Initialize the parser with necessary callbacks. Must be called before any
   /// data is passed to Parse().
   /// @param init_cb will be called once enough data has been parsed to
@@ -60,11 +63,14 @@ class MediaParser {
   ///        available from the parser.
   /// @param new_text_sample_cb will be called each time a new text sample is
   ///        available from the parser.
+  /// @param decoder_config_changed_cb will be called each time when the decoder
+  ///        config parameters changed.
   /// @param decryption_key_source the key source to decrypt the frames.  May be
   ///        NULL, and caller retains ownership.
   virtual void Init(const InitCB& init_cb,
                     const NewMediaSampleCB& new_media_sample_cb,
                     const NewTextSampleCB& new_text_sample_cb,
+                    const DecoderConfigChangedCB& decoder_config_changed_cb,
                     KeySource* decryption_key_source) = 0;
 
   /// Flush data currently in the parser and put the parser in a state where it

--- a/packager/media/base/media_parser.h
+++ b/packager/media/base/media_parser.h
@@ -53,7 +53,8 @@ class MediaParser {
       NewTextSampleCB;
 
   /// Called when the decoder config parameters have changed.
-  typedef base::Callback<void()> DecoderConfigChangedCB;
+  /// @param track_id is the id of the track that changed.
+  typedef base::Callback<void(uint32_t track_id)> DecoderConfigChangedCB;
 
   /// Initialize the parser with necessary callbacks. Must be called before any
   /// data is passed to Parse().

--- a/packager/media/demuxer/demuxer.cc
+++ b/packager/media/demuxer/demuxer.cc
@@ -343,8 +343,18 @@ bool Demuxer::NewTextSampleEvent(uint32_t track_id,
   return PushTextSample(track_id, sample);
 }
 
-void Demuxer::DecoderConfigChangedEvent() {
-  NotifyDecoderConfigChanged();
+void Demuxer::DecoderConfigChangedEvent(uint32_t track_id) {
+  auto stream_index_iter = track_id_to_stream_index_map_.find(track_id);
+  if (stream_index_iter == track_id_to_stream_index_map_.end()) {
+    LOG(ERROR) << "Track " << track_id << " not found.";
+    return;
+  }
+  if (stream_index_iter->second == kInvalidStreamIndex)
+    return;
+  Status status = NotifyDecoderConfigChanged(stream_index_iter->second);
+  if (!status.ok()) {
+    LOG(ERROR) << "Failed to notify for decoder config change: " << status;
+  }
 }
 
 bool Demuxer::PushMediaSample(uint32_t track_id,

--- a/packager/media/demuxer/demuxer.cc
+++ b/packager/media/demuxer/demuxer.cc
@@ -344,14 +344,10 @@ bool Demuxer::NewTextSampleEvent(uint32_t track_id,
 }
 
 void Demuxer::DecoderConfigChangedEvent(uint32_t track_id) {
-  auto stream_index_iter = track_id_to_stream_index_map_.find(track_id);
-  if (stream_index_iter == track_id_to_stream_index_map_.end()) {
-    LOG(ERROR) << "Track " << track_id << " not found.";
-    return;
-  }
-  if (stream_index_iter->second == kInvalidStreamIndex)
-    return;
-  Status status = NotifyDecoderConfigChanged(stream_index_iter->second);
+  // Notify all handlers of the change. This is necessary because the e.g the
+  // decoder config change for a video stream might have side-effects to audio
+  // streams as well.
+  Status status = NotifyAllDecoderConfigChanged();
   if (!status.ok()) {
     LOG(ERROR) << "Failed to notify for decoder config change: " << status;
   }

--- a/packager/media/demuxer/demuxer.cc
+++ b/packager/media/demuxer/demuxer.cc
@@ -343,7 +343,9 @@ bool Demuxer::NewTextSampleEvent(uint32_t track_id,
   return PushTextSample(track_id, sample);
 }
 
-void Demuxer::DecoderConfigChangedEvent() {}
+void Demuxer::DecoderConfigChangedEvent() {
+  NotifyDecoderConfigChanged();
+}
 
 bool Demuxer::PushMediaSample(uint32_t track_id,
                               std::shared_ptr<MediaSample> sample) {

--- a/packager/media/demuxer/demuxer.cc
+++ b/packager/media/demuxer/demuxer.cc
@@ -215,6 +215,7 @@ Status Demuxer::InitializeParser() {
       base::Bind(&Demuxer::ParserInitEvent, base::Unretained(this)),
       base::Bind(&Demuxer::NewMediaSampleEvent, base::Unretained(this)),
       base::Bind(&Demuxer::NewTextSampleEvent, base::Unretained(this)),
+      base::Bind(&Demuxer::DecoderConfigChangedEvent, base::Unretained(this)),
       key_source_.get());
 
   // Handle trailing 'moov'.
@@ -341,6 +342,8 @@ bool Demuxer::NewTextSampleEvent(uint32_t track_id,
   }
   return PushTextSample(track_id, sample);
 }
+
+void Demuxer::DecoderConfigChangedEvent() {}
 
 bool Demuxer::PushMediaSample(uint32_t track_id,
                               std::shared_ptr<MediaSample> sample) {

--- a/packager/media/demuxer/demuxer.h
+++ b/packager/media/demuxer/demuxer.h
@@ -119,7 +119,7 @@ class Demuxer : public OriginHandler {
                            std::shared_ptr<MediaSample> sample);
   bool NewTextSampleEvent(uint32_t track_id,
                           std::shared_ptr<TextSample> sample);
-  void DecoderConfigChangedEvent();
+  void DecoderConfigChangedEvent(uint32_t track_id);
   // Helper function to push the sample to corresponding stream.
   bool PushMediaSample(uint32_t track_id, std::shared_ptr<MediaSample> sample);
   bool PushTextSample(uint32_t track_id, std::shared_ptr<TextSample> sample);

--- a/packager/media/demuxer/demuxer.h
+++ b/packager/media/demuxer/demuxer.h
@@ -119,6 +119,7 @@ class Demuxer : public OriginHandler {
                            std::shared_ptr<MediaSample> sample);
   bool NewTextSampleEvent(uint32_t track_id,
                           std::shared_ptr<TextSample> sample);
+  void DecoderConfigChangedEvent();
   // Helper function to push the sample to corresponding stream.
   bool PushMediaSample(uint32_t track_id, std::shared_ptr<MediaSample> sample);
   bool PushTextSample(uint32_t track_id, std::shared_ptr<TextSample> sample);

--- a/packager/media/event/combined_muxer_listener.cc
+++ b/packager/media/event/combined_muxer_listener.cc
@@ -80,5 +80,11 @@ void CombinedMuxerListener::OnCueEvent(int64_t timestamp,
   }
 }
 
+void CombinedMuxerListener::OnDecoderConfigChanged() {
+  for (auto& listener : muxer_listeners_) {
+    listener->OnDecoderConfigChanged();
+  }
+}
+
 }  // namespace media
 }  // namespace shaka

--- a/packager/media/event/combined_muxer_listener.h
+++ b/packager/media/event/combined_muxer_listener.h
@@ -45,6 +45,7 @@ class CombinedMuxerListener : public MuxerListener {
                     uint64_t segment_file_size) override;
   void OnKeyFrame(int64_t timestamp, uint64_t start_byte_offset, uint64_t size);
   void OnCueEvent(int64_t timestamp, const std::string& cue_data) override;
+  void OnDecoderConfigChanged() override;
   /// @}
 
  protected:

--- a/packager/media/event/hls_notify_muxer_listener.cc
+++ b/packager/media/event/hls_notify_muxer_listener.cc
@@ -274,6 +274,10 @@ void HlsNotifyMuxerListener::OnCueEvent(int64_t timestamp,
   }
 }
 
+void HlsNotifyMuxerListener::OnDecoderConfigChanged() {
+  hls_notifier_->NotifyDecoderConfigChanged(stream_id_.value());
+}
+
 bool HlsNotifyMuxerListener::NotifyNewStream() {
   DCHECK(media_info_);
 

--- a/packager/media/event/hls_notify_muxer_listener.h
+++ b/packager/media/event/hls_notify_muxer_listener.h
@@ -70,6 +70,7 @@ class HlsNotifyMuxerListener : public MuxerListener {
                     uint64_t segment_file_size) override;
   void OnKeyFrame(int64_t timestamp, uint64_t start_byte_offset, uint64_t size);
   void OnCueEvent(int64_t timestamp, const std::string& cue_data) override;
+  void OnDecoderConfigChanged() override;
   /// @}
 
  private:

--- a/packager/media/event/hls_notify_muxer_listener_unittest.cc
+++ b/packager/media/event/hls_notify_muxer_listener_unittest.cc
@@ -53,6 +53,7 @@ class MockHlsNotifier : public hls::HlsNotifier {
                     uint64_t start_byte_offset,
                     uint64_t size));
   MOCK_METHOD2(NotifyCueEvent, bool(uint32_t stream_id, int64_t timestamp));
+  MOCK_METHOD1(NotifyDecoderConfigChanged, void(uint32_t stream_id));
   MOCK_METHOD5(
       NotifyEncryptionUpdate,
       bool(uint32_t stream_id,

--- a/packager/media/event/mock_muxer_listener.h
+++ b/packager/media/event/mock_muxer_listener.h
@@ -69,6 +69,8 @@ class MockMuxerListener : public MuxerListener {
 
   MOCK_METHOD2(OnCueEvent,
                void(int64_t timestamp, const std::string& cue_data));
+
+  MOCK_METHOD0(OnDecoderConfigChanged, void());
 };
 
 }  // namespace media

--- a/packager/media/event/mpd_notify_muxer_listener.cc
+++ b/packager/media/event/mpd_notify_muxer_listener.cc
@@ -213,6 +213,8 @@ void MpdNotifyMuxerListener::OnCueEvent(int64_t timestamp,
   }
 }
 
+void MpdNotifyMuxerListener::OnDecoderConfigChanged() {}
+
 bool MpdNotifyMuxerListener::NotifyNewContainer() {
   uint32_t notification_id;
   if (!mpd_notifier_->NotifyNewContainer(*media_info_, &notification_id)) {

--- a/packager/media/event/mpd_notify_muxer_listener.h
+++ b/packager/media/event/mpd_notify_muxer_listener.h
@@ -53,6 +53,7 @@ class MpdNotifyMuxerListener : public MuxerListener {
                     uint64_t segment_file_size) override;
   void OnKeyFrame(int64_t timestamp, uint64_t start_byte_offset, uint64_t size);
   void OnCueEvent(int64_t timestamp, const std::string& cue_data) override;
+  void OnDecoderConfigChanged() override;
   /// @}
 
   void set_accessibilities(const std::vector<std::string>& accessiblities) {

--- a/packager/media/event/muxer_listener.h
+++ b/packager/media/event/muxer_listener.h
@@ -143,6 +143,9 @@ class MuxerListener {
   /// @param cue_data is the data of the cue.
   virtual void OnCueEvent(int64_t timestamp, const std::string& cue_data) = 0;
 
+  /// Called when the decoder config parameters have changed.
+  virtual void OnDecoderConfigChanged() = 0;
+
  protected:
   MuxerListener() = default;
 };

--- a/packager/media/event/vod_media_info_dump_muxer_listener.cc
+++ b/packager/media/event/vod_media_info_dump_muxer_listener.cc
@@ -110,6 +110,8 @@ void VodMediaInfoDumpMuxerListener::OnCueEvent(int64_t timestamp,
   NOTIMPLEMENTED();
 }
 
+void VodMediaInfoDumpMuxerListener::OnDecoderConfigChanged() {}
+
 // static
 bool VodMediaInfoDumpMuxerListener::WriteMediaInfoToFile(
     const MediaInfo& media_info,

--- a/packager/media/event/vod_media_info_dump_muxer_listener.h
+++ b/packager/media/event/vod_media_info_dump_muxer_listener.h
@@ -54,6 +54,7 @@ class VodMediaInfoDumpMuxerListener : public MuxerListener {
                   uint64_t start_byte_offset,
                   uint64_t size) override;
   void OnCueEvent(int64_t timestamp, const std::string& cue_data) override;
+  void OnDecoderConfigChanged() override;
   /// @}
 
   /// Write @a media_info to @a output_file_path in human readable format.

--- a/packager/media/formats/mp2t/es_parser.h
+++ b/packager/media/formats/mp2t/es_parser.h
@@ -23,6 +23,7 @@ class EsParser {
   typedef base::Callback<void(std::shared_ptr<StreamInfo>)> NewStreamInfoCB;
   typedef base::Callback<void(std::shared_ptr<MediaSample>)> EmitSampleCB;
   typedef base::Callback<void(std::shared_ptr<TextSample>)> EmitTextSampleCB;
+  typedef base::Callback<void()> DecoderConfigChangedCB;
 
   EsParser(uint32_t pid) : pid_(pid) {}
   virtual ~EsParser() {}

--- a/packager/media/formats/mp2t/es_parser_h264.cc
+++ b/packager/media/formats/mp2t/es_parser_h264.cc
@@ -21,12 +21,14 @@ namespace mp2t {
 
 EsParserH264::EsParserH264(uint32_t pid,
                            const NewStreamInfoCB& new_stream_info_cb,
-                           const EmitSampleCB& emit_sample_cb)
+                           const EmitSampleCB& emit_sample_cb,
+                           const MediaParser::DecoderConfigChangedCB& decoder_config_changed_cb)
     : EsParserH26x(Nalu::kH264,
                    std::unique_ptr<H26xByteToUnitStreamConverter>(
                        new H264ByteToUnitStreamConverter()),
                    pid,
-                   emit_sample_cb),
+                   emit_sample_cb,
+                   decoder_config_changed_cb),
       new_stream_info_cb_(new_stream_info_cb),
       decoder_config_check_pending_(false),
       h264_parser_(new H264Parser()) {}
@@ -145,6 +147,7 @@ bool EsParserH264::UpdateVideoDecoderConfig(int pps_id) {
       // video resolution changes) should be treated as errors.
       LOG(WARNING) << "H.264 decoder configuration has changed.";
       last_video_decoder_config_->set_codec_config(decoder_config_record);
+      decoder_config_changed_cb().Run();
     }
     return true;
   }

--- a/packager/media/formats/mp2t/es_parser_h264.cc
+++ b/packager/media/formats/mp2t/es_parser_h264.cc
@@ -22,7 +22,7 @@ namespace mp2t {
 EsParserH264::EsParserH264(uint32_t pid,
                            const NewStreamInfoCB& new_stream_info_cb,
                            const EmitSampleCB& emit_sample_cb,
-                           const MediaParser::DecoderConfigChangedCB& decoder_config_changed_cb)
+                           const DecoderConfigChangedCB& decoder_config_changed_cb)
     : EsParserH26x(Nalu::kH264,
                    std::unique_ptr<H26xByteToUnitStreamConverter>(
                        new H264ByteToUnitStreamConverter()),

--- a/packager/media/formats/mp2t/es_parser_h264.h
+++ b/packager/media/formats/mp2t/es_parser_h264.h
@@ -26,7 +26,8 @@ class EsParserH264 : public EsParserH26x {
  public:
   EsParserH264(uint32_t pid,
                const NewStreamInfoCB& new_stream_info_cb,
-               const EmitSampleCB& emit_sample_cb);
+               const EmitSampleCB& emit_sample_cb,
+               const MediaParser::DecoderConfigChangedCB& decoder_config_changed_cb);
   ~EsParserH264() override;
 
   // EsParserH26x implementation override.

--- a/packager/media/formats/mp2t/es_parser_h264.h
+++ b/packager/media/formats/mp2t/es_parser_h264.h
@@ -27,7 +27,7 @@ class EsParserH264 : public EsParserH26x {
   EsParserH264(uint32_t pid,
                const NewStreamInfoCB& new_stream_info_cb,
                const EmitSampleCB& emit_sample_cb,
-               const MediaParser::DecoderConfigChangedCB& decoder_config_changed_cb);
+               const DecoderConfigChangedCB& decoder_config_changed_cb);
   ~EsParserH264() override;
 
   // EsParserH26x implementation override.

--- a/packager/media/formats/mp2t/es_parser_h264_unittest.cc
+++ b/packager/media/formats/mp2t/es_parser_h264_unittest.cc
@@ -135,6 +135,8 @@ class EsParserH264Test : public testing::Test {
     stream_map_[config->track_id()] = config;
   }
 
+  void DecoderConfigChanged() {}
+
   size_t sample_count() const { return sample_count_; }
   bool first_frame_is_key_frame() { return first_frame_is_key_frame_; }
 
@@ -170,7 +172,8 @@ void EsParserH264Test::ProcessPesPackets(
   EsParserH264 es_parser(
       0,
       base::Bind(&EsParserH264Test::NewVideoConfig, base::Unretained(this)),
-      base::Bind(&EsParserH264Test::EmitSample, base::Unretained(this)));
+      base::Bind(&EsParserH264Test::EmitSample, base::Unretained(this)),
+      base::Bind(&EsParserH264Test::DecoderConfigChanged, base::Unretained(this)));
 
   size_t au_idx = 0;
   for (size_t k = 0; k < pes_packets.size(); k++) {

--- a/packager/media/formats/mp2t/es_parser_h265.cc
+++ b/packager/media/formats/mp2t/es_parser_h265.cc
@@ -25,7 +25,7 @@ namespace mp2t {
 EsParserH265::EsParserH265(uint32_t pid,
                            const NewStreamInfoCB& new_stream_info_cb,
                            const EmitSampleCB& emit_sample_cb,
-                           const MediaParser::DecoderConfigChangedCB& decoder_config_changed_cb)
+                           const DecoderConfigChangedCB& decoder_config_changed_cb)
     : EsParserH26x(Nalu::kH265,
                    std::unique_ptr<H26xByteToUnitStreamConverter>(
                        new H265ByteToUnitStreamConverter()),

--- a/packager/media/formats/mp2t/es_parser_h265.cc
+++ b/packager/media/formats/mp2t/es_parser_h265.cc
@@ -24,12 +24,14 @@ namespace mp2t {
 
 EsParserH265::EsParserH265(uint32_t pid,
                            const NewStreamInfoCB& new_stream_info_cb,
-                           const EmitSampleCB& emit_sample_cb)
+                           const EmitSampleCB& emit_sample_cb,
+                           const MediaParser::DecoderConfigChangedCB& decoder_config_changed_cb)
     : EsParserH26x(Nalu::kH265,
                    std::unique_ptr<H26xByteToUnitStreamConverter>(
                        new H265ByteToUnitStreamConverter()),
                    pid,
-                   emit_sample_cb),
+                   emit_sample_cb,
+                   decoder_config_changed_cb),
       new_stream_info_cb_(new_stream_info_cb),
       decoder_config_check_pending_(false),
       h265_parser_(new H265Parser()) {}
@@ -150,6 +152,7 @@ bool EsParserH265::UpdateVideoDecoderConfig(int pps_id) {
       // video resolution changes) should be treated as errors.
       LOG(WARNING) << "H.265 decoder configuration has changed.";
       last_video_decoder_config_->set_codec_config(decoder_config_record);
+      decoder_config_changed_cb().Run();
     }
     return true;
   }

--- a/packager/media/formats/mp2t/es_parser_h265.h
+++ b/packager/media/formats/mp2t/es_parser_h265.h
@@ -29,7 +29,7 @@ class EsParserH265 : public EsParserH26x {
   EsParserH265(uint32_t pid,
                const NewStreamInfoCB& new_stream_info_cb,
                const EmitSampleCB& emit_sample_cb,
-               const MediaParser::DecoderConfigChangedCB& decoder_config_changed_cb);
+               const DecoderConfigChangedCB& decoder_config_changed_cb);
   ~EsParserH265() override;
 
   // EsParserH26x implementation override.

--- a/packager/media/formats/mp2t/es_parser_h265.h
+++ b/packager/media/formats/mp2t/es_parser_h265.h
@@ -28,7 +28,8 @@ class EsParserH265 : public EsParserH26x {
  public:
   EsParserH265(uint32_t pid,
                const NewStreamInfoCB& new_stream_info_cb,
-               const EmitSampleCB& emit_sample_cb);
+               const EmitSampleCB& emit_sample_cb,
+               const MediaParser::DecoderConfigChangedCB& decoder_config_changed_cb);
   ~EsParserH265() override;
 
   // EsParserH26x implementation override.

--- a/packager/media/formats/mp2t/es_parser_h26x.cc
+++ b/packager/media/formats/mp2t/es_parser_h26x.cc
@@ -31,9 +31,11 @@ EsParserH26x::EsParserH26x(
     Nalu::CodecType type,
     std::unique_ptr<H26xByteToUnitStreamConverter> stream_converter,
     uint32_t pid,
-    const EmitSampleCB& emit_sample_cb)
+    const EmitSampleCB& emit_sample_cb,
+    const MediaParser::DecoderConfigChangedCB& decoder_config_changed_cb)
     : EsParser(pid),
       emit_sample_cb_(emit_sample_cb),
+      decoder_config_changed_cb_(decoder_config_changed_cb),
       type_(type),
       es_queue_(new media::OffsetByteQueue()),
       stream_converter_(std::move(stream_converter)) {}

--- a/packager/media/formats/mp2t/es_parser_h26x.cc
+++ b/packager/media/formats/mp2t/es_parser_h26x.cc
@@ -32,7 +32,7 @@ EsParserH26x::EsParserH26x(
     std::unique_ptr<H26xByteToUnitStreamConverter> stream_converter,
     uint32_t pid,
     const EmitSampleCB& emit_sample_cb,
-    const MediaParser::DecoderConfigChangedCB& decoder_config_changed_cb)
+    const DecoderConfigChangedCB& decoder_config_changed_cb)
     : EsParser(pid),
       emit_sample_cb_(emit_sample_cb),
       decoder_config_changed_cb_(decoder_config_changed_cb),

--- a/packager/media/formats/mp2t/es_parser_h26x.h
+++ b/packager/media/formats/mp2t/es_parser_h26x.h
@@ -13,7 +13,6 @@
 
 #include "packager/base/callback.h"
 #include "packager/base/compiler_specific.h"
-#include "packager/media/base/media_parser.h"
 #include "packager/media/codecs/nalu_reader.h"
 #include "packager/media/formats/mp2t/es_parser.h"
 
@@ -32,7 +31,7 @@ class EsParserH26x : public EsParser {
                std::unique_ptr<H26xByteToUnitStreamConverter> stream_converter,
                uint32_t pid,
                const EmitSampleCB& emit_sample_cb,
-               const MediaParser::DecoderConfigChangedCB& decoder_config_changed_cb);
+               const DecoderConfigChangedCB& decoder_config_changed_cb);
   ~EsParserH26x() override;
 
   // EsParser implementation overrides.
@@ -54,7 +53,7 @@ class EsParserH26x : public EsParser {
     return stream_converter_.get();
   }
 
-  const MediaParser::DecoderConfigChangedCB& decoder_config_changed_cb() const {
+  const DecoderConfigChangedCB& decoder_config_changed_cb() const {
     return decoder_config_changed_cb_;
   }
 
@@ -107,7 +106,7 @@ class EsParserH26x : public EsParser {
   EmitSampleCB emit_sample_cb_;
 
   // Calback to notify about decoder config updates.
-  MediaParser::DecoderConfigChangedCB decoder_config_changed_cb_;
+  DecoderConfigChangedCB decoder_config_changed_cb_;
 
   // The type of stream being parsed.
   Nalu::CodecType type_;

--- a/packager/media/formats/mp2t/es_parser_h26x.h
+++ b/packager/media/formats/mp2t/es_parser_h26x.h
@@ -13,6 +13,7 @@
 
 #include "packager/base/callback.h"
 #include "packager/base/compiler_specific.h"
+#include "packager/media/base/media_parser.h"
 #include "packager/media/codecs/nalu_reader.h"
 #include "packager/media/formats/mp2t/es_parser.h"
 
@@ -30,7 +31,8 @@ class EsParserH26x : public EsParser {
   EsParserH26x(Nalu::CodecType type,
                std::unique_ptr<H26xByteToUnitStreamConverter> stream_converter,
                uint32_t pid,
-               const EmitSampleCB& emit_sample_cb);
+               const EmitSampleCB& emit_sample_cb,
+               const MediaParser::DecoderConfigChangedCB& decoder_config_changed_cb);
   ~EsParserH26x() override;
 
   // EsParser implementation overrides.
@@ -50,6 +52,10 @@ class EsParserH26x : public EsParser {
 
   const H26xByteToUnitStreamConverter* stream_converter() const {
     return stream_converter_.get();
+  }
+
+  const MediaParser::DecoderConfigChangedCB& decoder_config_changed_cb() const {
+    return decoder_config_changed_cb_;
   }
 
  private:
@@ -99,6 +105,9 @@ class EsParserH26x : public EsParser {
 
   // Callback to pass the frames.
   EmitSampleCB emit_sample_cb_;
+
+  // Calback to notify about decoder config updates.
+  MediaParser::DecoderConfigChangedCB decoder_config_changed_cb_;
 
   // The type of stream being parsed.
   Nalu::CodecType type_;

--- a/packager/media/formats/mp2t/es_parser_h26x_unittest.cc
+++ b/packager/media/formats/mp2t/es_parser_h26x_unittest.cc
@@ -78,7 +78,7 @@ class TestableEsParser : public EsParserH26x {
   TestableEsParser(Nalu::CodecType codec_type,
                    const NewStreamInfoCB& new_stream_info_cb,
                    const EmitSampleCB& emit_sample_cb,
-                   const MediaParser::DecoderConfigChangedCB& decoder_config_changed_cb)
+                   const DecoderConfigChangedCB& decoder_config_changed_cb)
       : EsParserH26x(codec_type,
                      std::unique_ptr<H26xByteToUnitStreamConverter>(
                          new FakeByteToUnitStreamConverter(codec_type)),

--- a/packager/media/formats/mp2t/mp2t_media_parser.cc
+++ b/packager/media/formats/mp2t/mp2t_media_parser.cc
@@ -158,6 +158,7 @@ Mp2tMediaParser::~Mp2tMediaParser() {}
 void Mp2tMediaParser::Init(const InitCB& init_cb,
                            const NewMediaSampleCB& new_media_sample_cb,
                            const NewTextSampleCB& new_text_sample_cb,
+                           const DecoderConfigChangedCB& decoder_config_changed_cb,
                            KeySource* decryption_key_source) {
   DCHECK(!is_initialized_);
   DCHECK(init_cb_.is_null());
@@ -168,6 +169,7 @@ void Mp2tMediaParser::Init(const InitCB& init_cb,
   init_cb_ = init_cb;
   new_media_sample_cb_ = new_media_sample_cb;
   new_text_sample_cb_ = new_text_sample_cb;
+  decoder_config_changed_cb_ = decoder_config_changed_cb;
 }
 
 bool Mp2tMediaParser::Flush() {
@@ -295,10 +297,12 @@ void Mp2tMediaParser::RegisterPes(int pmt_pid,
                                  base::Unretained(this), pes_pid);
   switch (stream_type) {
     case TsStreamType::kAvc:
-      es_parser.reset(new EsParserH264(pes_pid, on_new_stream, on_emit_media));
+      es_parser.reset(new EsParserH264(pes_pid, on_new_stream, on_emit_media,
+                                       decoder_config_changed_cb_));
       break;
     case TsStreamType::kHevc:
-      es_parser.reset(new EsParserH265(pes_pid, on_new_stream, on_emit_media));
+      es_parser.reset(new EsParserH265(pes_pid, on_new_stream, on_emit_media,
+                                       decoder_config_changed_cb_));
       break;
     case TsStreamType::kAdtsAac:
     case TsStreamType::kMpeg1Audio:

--- a/packager/media/formats/mp2t/mp2t_media_parser.h
+++ b/packager/media/formats/mp2t/mp2t_media_parser.h
@@ -68,6 +68,7 @@ class Mp2tMediaParser : public MediaParser {
                          std::shared_ptr<MediaSample> new_sample);
   void OnEmitTextSample(uint32_t pes_pid,
                         std::shared_ptr<TextSample> new_sample);
+  void OnDecoderConfigChanged(uint32_t pes_pid);
 
   // Invoke the initialization callback if needed.
   bool FinishInitializationIfNeeded();

--- a/packager/media/formats/mp2t/mp2t_media_parser.h
+++ b/packager/media/formats/mp2t/mp2t_media_parser.h
@@ -36,6 +36,7 @@ class Mp2tMediaParser : public MediaParser {
   void Init(const InitCB& init_cb,
             const NewMediaSampleCB& new_media_sample_cb,
             const NewTextSampleCB& new_text_sample_cb,
+            const DecoderConfigChangedCB& decoder_config_changed_cb,
             KeySource* decryption_key_source) override;
   bool Flush() override WARN_UNUSED_RESULT;
   bool Parse(const uint8_t* buf, int size) override WARN_UNUSED_RESULT;
@@ -83,6 +84,7 @@ class Mp2tMediaParser : public MediaParser {
   InitCB init_cb_;
   NewMediaSampleCB new_media_sample_cb_;
   NewTextSampleCB new_text_sample_cb_;
+  DecoderConfigChangedCB decoder_config_changed_cb_;
 
   bool sbr_in_mimetype_;
 

--- a/packager/media/formats/mp2t/mp2t_media_parser_unittest.cc
+++ b/packager/media/formats/mp2t/mp2t_media_parser_unittest.cc
@@ -100,7 +100,7 @@ class Mp2tMediaParserTest : public testing::Test {
     return false;
   }
 
-  void OnDecoderConfigChanged() {}
+  void OnDecoderConfigChanged(uint32_t track_id) {}
 
   void InitializeParser() {
     parser_->Init(

--- a/packager/media/formats/mp2t/mp2t_media_parser_unittest.cc
+++ b/packager/media/formats/mp2t/mp2t_media_parser_unittest.cc
@@ -100,12 +100,15 @@ class Mp2tMediaParserTest : public testing::Test {
     return false;
   }
 
+  void OnDecoderConfigChanged() {}
+
   void InitializeParser() {
     parser_->Init(
         base::Bind(&Mp2tMediaParserTest::OnInit, base::Unretained(this)),
         base::Bind(&Mp2tMediaParserTest::OnNewSample, base::Unretained(this)),
         base::Bind(&Mp2tMediaParserTest::OnNewTextSample,
                    base::Unretained(this)),
+        base::Bind(&Mp2tMediaParserTest::OnDecoderConfigChanged, base::Unretained(this)),
         NULL);
   }
 

--- a/packager/media/formats/mp4/mp4_media_parser.cc
+++ b/packager/media/formats/mp4/mp4_media_parser.cc
@@ -185,6 +185,7 @@ MP4MediaParser::~MP4MediaParser() {}
 void MP4MediaParser::Init(const InitCB& init_cb,
                           const NewMediaSampleCB& new_media_sample_cb,
                           const NewTextSampleCB& new_text_sample_cb,
+                          const DecoderConfigChangedCB& decoder_config_changed_cb,
                           KeySource* decryption_key_source) {
   DCHECK_EQ(state_, kWaitingForInit);
   DCHECK(init_cb_.is_null());

--- a/packager/media/formats/mp4/mp4_media_parser.h
+++ b/packager/media/formats/mp4/mp4_media_parser.h
@@ -37,6 +37,7 @@ class MP4MediaParser : public MediaParser {
   void Init(const InitCB& init_cb,
             const NewMediaSampleCB& new_media_sample_cb,
             const NewTextSampleCB& new_text_sample_cb,
+            const DecoderConfigChangedCB& decoder_config_changed_cb,
             KeySource* decryption_key_source) override;
   bool Flush() override WARN_UNUSED_RESULT;
   bool Parse(const uint8_t* buf, int size) override WARN_UNUSED_RESULT;

--- a/packager/media/formats/mp4/mp4_media_parser_unittest.cc
+++ b/packager/media/formats/mp4/mp4_media_parser_unittest.cc
@@ -93,11 +93,14 @@ class MP4MediaParserTest : public testing::Test {
     return false;
   }
 
+  void DecoderConfigChangedF() {}
+
   void InitializeParser(KeySource* decryption_key_source) {
     parser_->Init(
         base::Bind(&MP4MediaParserTest::InitF, base::Unretained(this)),
         base::Bind(&MP4MediaParserTest::NewSampleF, base::Unretained(this)),
         base::Bind(&MP4MediaParserTest::NewTextSampleF, base::Unretained(this)),
+        base::Bind(&MP4MediaParserTest::DecoderConfigChangedF, base::Unretained(this)),
         decryption_key_source);
   }
 

--- a/packager/media/formats/mp4/mp4_media_parser_unittest.cc
+++ b/packager/media/formats/mp4/mp4_media_parser_unittest.cc
@@ -93,7 +93,7 @@ class MP4MediaParserTest : public testing::Test {
     return false;
   }
 
-  void DecoderConfigChangedF() {}
+  void DecoderConfigChangedF(uint32_t track_id) {}
 
   void InitializeParser(KeySource* decryption_key_source) {
     parser_->Init(

--- a/packager/media/formats/mp4/mp4_muxer.cc
+++ b/packager/media/formats/mp4/mp4_muxer.cc
@@ -373,8 +373,9 @@ Status MP4Muxer::UpdateEditListOffsetFromSample(const MediaSample& sample) {
   return Status::OK;
 }
 
-void MP4Muxer::OnDecoderConfigChanged() {
+Status MP4Muxer::OnDecoderConfigChanged(size_t input_stream_index) {
   muxer_listener()->OnDecoderConfigChanged();
+  return Status::OK;
 }
 
 void MP4Muxer::InitializeTrak(const StreamInfo* info, Track* trak) {

--- a/packager/media/formats/mp4/mp4_muxer.cc
+++ b/packager/media/formats/mp4/mp4_muxer.cc
@@ -373,6 +373,10 @@ Status MP4Muxer::UpdateEditListOffsetFromSample(const MediaSample& sample) {
   return Status::OK;
 }
 
+void MP4Muxer::OnDecoderConfigChanged() {
+  muxer_listener()->OnDecoderConfigChanged();
+}
+
 void MP4Muxer::InitializeTrak(const StreamInfo* info, Track* trak) {
   int64_t now = IsoTimeNow();
   trak->header.creation_time = now;

--- a/packager/media/formats/mp4/mp4_muxer.h
+++ b/packager/media/formats/mp4/mp4_muxer.h
@@ -35,6 +35,10 @@ class MP4Muxer : public Muxer {
   explicit MP4Muxer(const MuxerOptions& options);
   ~MP4Muxer() override;
 
+ protected:
+  // MediaHandler implementation overrides.
+  void OnDecoderConfigChanged() override;
+
  private:
   // Muxer implementation overrides.
   Status InitializeMuxer() override;

--- a/packager/media/formats/mp4/mp4_muxer.h
+++ b/packager/media/formats/mp4/mp4_muxer.h
@@ -37,7 +37,7 @@ class MP4Muxer : public Muxer {
 
  protected:
   // MediaHandler implementation overrides.
-  void OnDecoderConfigChanged() override;
+  Status OnDecoderConfigChanged(size_t input_stream_index) override;
 
  private:
   // Muxer implementation overrides.

--- a/packager/media/formats/webm/webm_media_parser.cc
+++ b/packager/media/formats/webm/webm_media_parser.cc
@@ -28,6 +28,7 @@ WebMMediaParser::~WebMMediaParser() {}
 void WebMMediaParser::Init(const InitCB& init_cb,
                            const NewMediaSampleCB& new_media_sample_cb,
                            const NewTextSampleCB& new_text_sample_cb,
+                           const DecoderConfigChangedCB& decoder_config_changed_cb,
                            KeySource* decryption_key_source) {
   DCHECK_EQ(state_, kWaitingForInit);
   DCHECK(init_cb_.is_null());

--- a/packager/media/formats/webm/webm_media_parser.h
+++ b/packager/media/formats/webm/webm_media_parser.h
@@ -25,6 +25,7 @@ class WebMMediaParser : public MediaParser {
   void Init(const InitCB& init_cb,
             const NewMediaSampleCB& new_media_sample_cb,
             const NewTextSampleCB& new_text_sample_cb,
+            const DecoderConfigChangedCB& decoder_config_changed_cb,
             KeySource* decryption_key_source) override;
   bool Flush() override WARN_UNUSED_RESULT;
   bool Parse(const uint8_t* buf, int size) override WARN_UNUSED_RESULT;

--- a/packager/media/formats/webvtt/webvtt_parser.cc
+++ b/packager/media/formats/webvtt/webvtt_parser.cc
@@ -193,6 +193,7 @@ WebVttParser::WebVttParser() {}
 void WebVttParser::Init(const InitCB& init_cb,
                         const NewMediaSampleCB& new_media_sample_cb,
                         const NewTextSampleCB& new_text_sample_cb,
+                        const DecoderConfigChangedCB& decoder_config_changed_cb,
                         KeySource* decryption_key_source) {
   DCHECK(init_cb_.is_null());
   DCHECK(!init_cb.is_null());

--- a/packager/media/formats/webvtt/webvtt_parser.h
+++ b/packager/media/formats/webvtt/webvtt_parser.h
@@ -27,6 +27,7 @@ class WebVttParser : public MediaParser {
   void Init(const InitCB& init_cb,
             const NewMediaSampleCB& new_media_sample_cb,
             const NewTextSampleCB& new_text_sample_cb,
+            const DecoderConfigChangedCB& decoder_config_changed_cb,
             KeySource* decryption_key_source) override;
   bool Flush() override;
   bool Parse(const uint8_t* buf, int size) override;

--- a/packager/media/formats/webvtt/webvtt_parser_unittest.cc
+++ b/packager/media/formats/webvtt/webvtt_parser_unittest.cc
@@ -52,6 +52,7 @@ class WebVttParserTest : public testing::Test {
         base::Bind(&WebVttParserTest::InitCB, base::Unretained(this)),
         base::Bind(&WebVttParserTest::NewMediaSampleCB, base::Unretained(this)),
         base::Bind(&WebVttParserTest::NewTextSampleCB, base::Unretained(this)),
+        base::Bind(&WebVttParserTest::DecoderConfigChangedCB, base::Unretained(this)),
         nullptr);
   }
 
@@ -70,6 +71,8 @@ class WebVttParserTest : public testing::Test {
     samples_.emplace_back(std::move(sample));
     return true;
   }
+
+  void DecoderConfigChangedCB() {}
 
   std::shared_ptr<WebVttParser> parser_;
   std::vector<std::shared_ptr<StreamInfo>> streams_;

--- a/packager/media/formats/webvtt/webvtt_parser_unittest.cc
+++ b/packager/media/formats/webvtt/webvtt_parser_unittest.cc
@@ -72,7 +72,7 @@ class WebVttParserTest : public testing::Test {
     return true;
   }
 
-  void DecoderConfigChangedCB() {}
+  void DecoderConfigChangedCB(uint32_t track_id) {}
 
   std::shared_ptr<WebVttParser> parser_;
   std::vector<std::shared_ptr<StreamInfo>> streams_;

--- a/packager/media/formats/wvm/wvm_media_parser.cc
+++ b/packager/media/formats/wvm/wvm_media_parser.cc
@@ -114,6 +114,7 @@ WvmMediaParser::~WvmMediaParser() {}
 void WvmMediaParser::Init(const InitCB& init_cb,
                           const NewMediaSampleCB& new_media_sample_cb,
                           const NewTextSampleCB& new_text_sample_cb,
+                          const DecoderConfigChangedCB& decoder_config_changed_cb,
                           KeySource* decryption_key_source) {
   DCHECK(!is_initialized_);
   DCHECK(!init_cb.is_null());

--- a/packager/media/formats/wvm/wvm_media_parser.h
+++ b/packager/media/formats/wvm/wvm_media_parser.h
@@ -58,6 +58,7 @@ class WvmMediaParser : public MediaParser {
   void Init(const InitCB& init_cb,
             const NewMediaSampleCB& new_media_sample_cb,
             const NewTextSampleCB& new_text_sample_cb,
+            const DecoderConfigChangedCB& decoder_config_changed_cb,
             KeySource* decryption_key_source) override;
   bool Flush() override WARN_UNUSED_RESULT;
   bool Parse(const uint8_t* buf, int size) override WARN_UNUSED_RESULT;

--- a/packager/media/formats/wvm/wvm_media_parser_unittest.cc
+++ b/packager/media/formats/wvm/wvm_media_parser_unittest.cc
@@ -141,7 +141,7 @@ class WvmMediaParserTest : public testing::Test {
     return false;
   }
 
-  void OnDecoderConfigChanged() {}
+  void OnDecoderConfigChanged(uint32_t track_id) {}
 
   void InitializeParser() {
     parser_->Init(

--- a/packager/media/formats/wvm/wvm_media_parser_unittest.cc
+++ b/packager/media/formats/wvm/wvm_media_parser_unittest.cc
@@ -141,12 +141,15 @@ class WvmMediaParserTest : public testing::Test {
     return false;
   }
 
+  void OnDecoderConfigChanged() {}
+
   void InitializeParser() {
     parser_->Init(
         base::Bind(&WvmMediaParserTest::OnInit, base::Unretained(this)),
         base::Bind(&WvmMediaParserTest::OnNewSample, base::Unretained(this)),
         base::Bind(&WvmMediaParserTest::OnNewTextSample,
                    base::Unretained(this)),
+        base::Bind(&WvmMediaParserTest::OnDecoderConfigChanged, base::Unretained(this)),
         key_source_.get());
   }
 


### PR DESCRIPTION
When a HLS stream has mid-stream changes in its decoding parameters, like an aspect ratio switch, this change is not always applied by some players (iOS, VLC).

This PR fixes this behaviour by inserting a `#EXT-X-DISCONTINUITY` into the media playlists every time a decoder config change happens and SPS/PPS/.. NALUs are sent.

See [RFC8216 Section 4.3.2.3](https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.2.3):
> The EXT-X-DISCONTINUITY tag SHOULD be present if there is a change in any of the following characteristics:
>   -  encoding parameters
>   -  encoding sequence

I'm not yet sure how this should play together with the `--strip_parameter_set_nalus` parameter. Maybe the discontinuity should only be injected if the SPS NALUs are not stripped?