### PR TITLE
ci: Use GITHUB_TOKEN instead of SHAKA_BOT_TOKEN

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -47,7 +47,3 @@
  - `NPM_PACKAGE_NAME`: Not a true "secret", but stored here to avoid someone
    pushing bogus packages to NPM during CI testing from a fork
    - In a fork, set to a private name which differs from the production one
- - `SHAKA_BOT_TOKEN`: A GitHub personal access token for the `shaka-bot`
-   account, with `workflow` scope
-   - To generate, visit https://github.com/settings/tokens/new and select the
-     `workflow` scope

--- a/.github/workflows/github_release.yaml
+++ b/.github/workflows/github_release.yaml
@@ -84,7 +84,7 @@ jobs:
         id: draft_release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.SHAKA_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ needs.setup.outputs.tag }}
           release_name: ${{ needs.setup.outputs.tag }}
@@ -170,7 +170,7 @@ jobs:
         if: matrix.build_type == 'Release' && matrix.lib_type == 'static'
         uses: dwenegar/upload-release-assets@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.SHAKA_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           release_id: ${{ needs.draft_release.outputs.release_id }}
           assets_path: artifacts
@@ -183,6 +183,6 @@ jobs:
       - name: Publish release
         uses: eregon/publish-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.SHAKA_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           release_id: ${{ needs.draft_release.outputs.release_id }}

--- a/.github/workflows/update_docs.yaml
+++ b/.github/workflows/update_docs.yaml
@@ -45,6 +45,6 @@ jobs:
       - name: Deploy to gh-pages branch
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.SHAKA_BOT_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: gh-pages
           full_commit_message: Generate docs for ${{ steps.ref.outputs.ref }}


### PR DESCRIPTION
There is not a good reason to use a long-lived token attached to
@shaka-bot.  Instead, use a short-lived, automatic token generated by
GitHub Actions for the workflow run.