### PR TITLE
ci: Produce static release executables on Linux

### DIFF
--- a/.github/workflows/custom-actions/build-packager/action.yaml
+++ b/.github/workflows/custom-actions/build-packager/action.yaml
@@ -88,11 +88,16 @@ runs:
         fi
         if [[ "${{ runner.os }}" == "Linux" ]]; then
           echo "::group::Check for static executables"
-          # Prove that we built static executables on Linux.  "ldd" will fail
-          # if the executable is not dynamically linked, so fail the workflow
-          # if "ldd" succeeds.
-          ldd packager && exit 1
-          ldd mpd_generator && exit 1
+          (
+            cd src/out/Release${{ inputs.build_type_suffix }}
+            # Prove that we built static executables on Linux.  First, check that
+            # the executables exist, and fail if they do not.  Then check "ldd",
+            # which will fail if the executable is not dynamically linked.  If
+            # "ldd" succeeds, we fail the workflow.
+            (test -x packager && test -x mpd_generator) || exit 1
+            ldd packager && exit 1
+            ldd mpd_generator && exit 1
+          )
           echo "::endgroup::"
         fi
         echo "::group::Prepare artifacts folder"

--- a/.github/workflows/custom-actions/build-packager/action.yaml
+++ b/.github/workflows/custom-actions/build-packager/action.yaml
@@ -97,8 +97,8 @@ runs:
             # that the last executed statement will be a success, and the step
             # won't be failed if we get that far.
             ls packager mpd_generator >/dev/null || exit 1
-            ldd packager && exit 1
-            ldd mpd_generator && exit 1
+            ldd packager 2>&1 && exit 1
+            ldd mpd_generator 2>&1 && exit 1
             true
           )
           echo "::endgroup::"
@@ -107,6 +107,10 @@ runs:
         mkdir artifacts
         ARTIFACTS="$GITHUB_WORKSPACE/artifacts"
         cd src/out/Release${{ inputs.build_type_suffix }}
+        echo "::endgroup::"
+        echo "::group::Strip executables"
+        strip packager${{ inputs.exe_ext }}
+        strip mpd_generator${{ inputs.exe_ext }}
         echo "::endgroup::"
         echo "::group::Copy packager"
         cp packager${{ inputs.exe_ext }} \

--- a/.github/workflows/custom-actions/build-packager/action.yaml
+++ b/.github/workflows/custom-actions/build-packager/action.yaml
@@ -63,6 +63,11 @@ runs:
       shell: bash
       run: |
         echo "::group::Sync gclient"
+        BUILD_CONFIG="${{ inputs.build_type }}-${{ inputs.lib_type }}"
+        if [[ "$BUILD_CONFIG" == "Release-static" && "${{ runner.os }}" == "Linux" ]]; then
+          # For static release builds, set these two additional flags for fully static binaries.
+          export GYP_DEFINES="$GYP_DEFINES disable_fatal_linker_warnings=1 static_link_binaries=1"
+        fi
         gclient sync
         echo "::endgroup::"
 
@@ -80,6 +85,15 @@ runs:
         if [[ "$BUILD_CONFIG" != "Release-static" ]]; then
           echo "Skipping artifacts for $BUILD_CONFIG."
           exit 0
+        fi
+        if [[ "${{ runner.os }}" == "Linux" ]]; then
+          echo "::group::Check for static executables"
+          # Prove that we built static executables on Linux.  "ldd" will fail
+          # if the executable is not dynamically linked, so fail the workflow
+          # if "ldd" succeeds.
+          ldd packager && exit 1
+          ldd mpd_generator && exit 1
+          echo "::endgroup::"
         fi
         echo "::group::Prepare artifacts folder"
         mkdir artifacts

--- a/.github/workflows/custom-actions/build-packager/action.yaml
+++ b/.github/workflows/custom-actions/build-packager/action.yaml
@@ -93,10 +93,13 @@ runs:
             # Prove that we built static executables on Linux.  First, check that
             # the executables exist, and fail if they do not.  Then check "ldd",
             # which will fail if the executable is not dynamically linked.  If
-            # "ldd" succeeds, we fail the workflow.
-            (test -x packager && test -x mpd_generator) || exit 1
+            # "ldd" succeeds, we fail the workflow.  Finally, we call "true" so
+            # that the last executed statement will be a success, and the step
+            # won't be failed if we get that far.
+            ls packager mpd_generator >/dev/null || exit 1
             ldd packager && exit 1
             ldd mpd_generator && exit 1
+            true
           )
           echo "::endgroup::"
         fi


### PR DESCRIPTION
We never produced static release executables on Linux before, but the dynamic libraries they depended on were universal enough that nobody noticed.  Now that we have released v2.5 and switched to GitHub Actions for CI builds, the Linux executables depend on libatomic, which is causing issues for some users.

Although we can't create fully-static executables on macOS or Windows, we can at least do so on Linux.

This adds a GYP variable `static_link_binaries` which can be set to request full-static binaries on Linux.  This also exposes the Chromium build variable `disable_fatal_linker_warnings`, which is necessary when static linking on Linux due to static-link-related warnings generated by libcurl for its use of `getaddrinfo`.  Finally, this enforces the definition of `__UCLIBC__` with static linking on Linux, which is the only way to disable malloc hooks in Chromium base.  Those hooks cause linker failures when linking statically on Linux.

A new check has been added to the release workflow to ensure that the builds we create are statically linked on Linux.

Closes #965