### PR TITLE
Low latency DASH support 

### DIFF
--- a/docs/source/options/dash_options.rst
+++ b/docs/source/options/dash_options.rst
@@ -95,3 +95,8 @@ DASH options
 
     If enabled, allow adaptive switching between different codecs, if they have 
     the same language, media type (audio, video etc) and container type.
+
+--is_low_latency_dash
+
+    If enabled, LL-DASH streaming will be used,
+    reducing overall latency by decoupling latency from segment duration.

--- a/docs/source/options/dash_options.rst
+++ b/docs/source/options/dash_options.rst
@@ -96,7 +96,7 @@ DASH options
     If enabled, allow adaptive switching between different codecs, if they have 
     the same language, media type (audio, video etc) and container type.
 
---is_low_latency_dash
+--low_latency_dash_mode
 
     If enabled, LL-DASH streaming will be used,
     reducing overall latency by decoupling latency from segment duration.

--- a/docs/source/tutorials/low_latency.rst
+++ b/docs/source/tutorials/low_latency.rst
@@ -1,0 +1,99 @@
+####################################
+Low Latency DASH (LL-DASH) Streaming
+####################################
+
+************
+Introduction
+************
+
+If ``--is_low_latency_dash`` is enabled, low latency DASH (LL-DASH) packaging will be used.
+
+This will reduce overall latency by ensuring that the media segments are chunk encoded and delivered via an aggregating response.
+The combination of these features will ensure that overall latency can be decoupled from the segment duration.
+For low latency to be achieved, the output of Shaka Packager must be combined with a delivery system which can chain together a set of aggregating responses, such as chunked transfer encoding under HTTP/1.1 or a HTTP/2 or HTTP/3 connection.
+The output of Shaka Packager must be played DASH client which understands the availabilityTimeOffset MPD value.
+Furthermore, the player should also understand the throughput estimation and ABR challenges that arise when operating in the low latency regime.
+
+This tutorial covers LL-DASH packaging and uses features from the DASH, HTTP upload, and FFmpeg piping tutorials.
+For more information on DASH, see :doc:`dash`; for HTTP upload, see :doc:`http_upload`;
+for FFmpeg piping, see :doc:`ffmpeg_piping`;
+for full documentation, see :doc:`/documentation`.
+
+*************
+Documentation
+*************
+
+Getting started
+===============
+
+To enable LL-DASH mode, use set the ``--is_low_latency_dash`` flag to ``true``. 
+
+All HTTP requests will use chunked transfer encoding:
+``Transfer-Encoding: chunked``.
+
+.. note::
+
+    Only LL-DASH is supported. LL-HLS support is yet to come.
+
+Synopsis
+========
+
+Here is a basic example of the low latency feature. 
+The LL-DASH streaming borrows features from "FFmpeg piping" and "HTTP upload",
+see :doc:`ffmpeg_piping` and :doc:`http_upload`.
+
+Define UNIX pipe to connect ffmpeg with packager::
+
+    export PIPE=/tmp/bigbuckbunny.fifo
+    mkfifo ${PIPE}
+
+Acquire and transcode RTMP stream::
+
+    # Steady
+    ffmpeg -fflags nobuffer -threads 0 -y \
+        -i rtmp://184.72.239.149/vod/mp4:bigbuckbunny_450.mp4 \
+        -pix_fmt yuv420p -vcodec libx264 -preset:v superfast -acodec aac \
+        -f mpegts pipe: > ${PIPE}
+
+Configure and run packager::
+
+    # Define upload URL
+    export UPLOAD_URL=http://localhost:6767/ll-dash
+
+    # Go
+    packager \
+        "input=${PIPE},stream=audio,init_segment=${UPLOAD_URL}_init.m4s,segment_template=${UPLOAD_URL}/bigbuckbunny-audio-aac-\$Number%04d\$.m4s" \
+        "input=${PIPE},stream=video,init_segment=${UPLOAD_URL}_init.m4s,segment_template=${UPLOAD_URL}/bigbuckbunny-video-h264-450-\$Number%04d\$.m4s" \
+        --io_block_size 65536 \
+        --segment_duration 2 \
+        --is_low_latency_dash=true \
+        --mpd_output "${UPLOAD_URL}/bigbuckbunny.mpd" \
+
+
+*************************
+Low Latency Compatibility
+*************************
+
+For low latency to be achieved, the processes handling Shaka Packager's output, such as the server and player,
+must support LL-DASH streaming.
+
+Delivery Pipeline
+=================
+Shaka Packager will upload the LL-DASH content to the specified output via HTTP chunked transfer encoding.
+The server must have the ability to handle this type of request. If using a proxy or shim for cloud authentication,
+these services must also support HTTP chunked transfer endoding.
+
+Examples of supporting content delivery systems:
+
+* AWS MediaStore
+
+Player
+======
+The player must support LL-DASH playout.
+LL-DASH requires the player to be able to interpret ``availabilityTimeOffset`` values from the DASH MPD.
+The player should also recognize the the throughput estimation and ABR challenges that arise with low latency streaming.
+
+Examples of supporting players:
+
+* Shaka Player? 
+* dash.js

--- a/docs/source/tutorials/low_latency.rst
+++ b/docs/source/tutorials/low_latency.rst
@@ -86,6 +86,9 @@ these services must also support HTTP chunked transfer encoding.
 Examples of supporting content delivery systems:
 
 * `AWS MediaStore <https://aws.amazon.com/mediastore/>`_
+* `s3-upload-proxy <https://github.com/fsouza/s3-upload-proxy>`_
+* `Streamline Low Latency DASH preview <https://github.com/streamlinevideo/low-latency-preview>`_
+* `go-chunked-streaming-server <https://github.com/mjneil/go-chunked-streaming-server>`_
 
 Player
 ======
@@ -97,3 +100,4 @@ Examples of supporting players:
 
 * `Shaka Player <https://github.com/google/shaka-player>`_
 * `dash.js <https://github.com/Dash-Industry-Forum/dash.js>`_
+* `Streamline Low Latency DASH preview <https://github.com/streamlinevideo/low-latency-preview>`_

--- a/docs/source/tutorials/low_latency.rst
+++ b/docs/source/tutorials/low_latency.rst
@@ -26,7 +26,7 @@ Documentation
 Getting started
 ===============
 
-To enable LL-DASH mode, use set the ``--is_low_latency_dash`` flag to ``true``. 
+To enable LL-DASH mode, set the ``--is_low_latency_dash`` flag to ``true``. 
 
 All HTTP requests will use chunked transfer encoding:
 ``Transfer-Encoding: chunked``.
@@ -38,8 +38,8 @@ All HTTP requests will use chunked transfer encoding:
 Synopsis
 ========
 
-Here is a basic example of the low latency feature. 
-The LL-DASH streaming borrows features from "FFmpeg piping" and "HTTP upload",
+Here is a basic example of the LL-DASH support. 
+The LL-DASH setup borrows features from "FFmpeg piping" and "HTTP upload",
 see :doc:`ffmpeg_piping` and :doc:`http_upload`.
 
 Define UNIX pipe to connect ffmpeg with packager::
@@ -49,7 +49,6 @@ Define UNIX pipe to connect ffmpeg with packager::
 
 Acquire and transcode RTMP stream::
 
-    # Steady
     ffmpeg -fflags nobuffer -threads 0 -y \
         -i rtmp://184.72.239.149/vod/mp4:bigbuckbunny_450.mp4 \
         -pix_fmt yuv420p -vcodec libx264 -preset:v superfast -acodec aac \
@@ -67,6 +66,7 @@ Configure and run packager::
         --io_block_size 65536 \
         --segment_duration 2 \
         --is_low_latency_dash=true \
+        --utc_timings "urn:mpeg:dash:utc:http-xsdate:2014"="https://time.akamai.com/?iso" \
         --mpd_output "${UPLOAD_URL}/bigbuckbunny.mpd" \
 
 
@@ -81,11 +81,11 @@ Delivery Pipeline
 =================
 Shaka Packager will upload the LL-DASH content to the specified output via HTTP chunked transfer encoding.
 The server must have the ability to handle this type of request. If using a proxy or shim for cloud authentication,
-these services must also support HTTP chunked transfer endoding.
+these services must also support HTTP chunked transfer encoding.
 
 Examples of supporting content delivery systems:
 
-* AWS MediaStore
+* `AWS MediaStore <https://aws.amazon.com/mediastore/>`_
 
 Player
 ======
@@ -95,5 +95,5 @@ The player should also recognize the the throughput estimation and ABR challenge
 
 Examples of supporting players:
 
-* Shaka Player? 
-* dash.js
+* `Shaka Player <https://github.com/google/shaka-player>`_
+* `dash.js <https://github.com/Dash-Industry-Forum/dash.js>`_

--- a/docs/source/tutorials/low_latency.rst
+++ b/docs/source/tutorials/low_latency.rst
@@ -6,7 +6,7 @@ Low Latency DASH (LL-DASH) Streaming
 Introduction
 ************
 
-If ``--is_low_latency_dash`` is enabled, low latency DASH (LL-DASH) packaging will be used.
+If ``--low_latency_dash_mode`` is enabled, low latency DASH (LL-DASH) packaging will be used.
 
 This will reduce overall latency by ensuring that the media segments are chunk encoded and delivered via an aggregating response.
 The combination of these features will ensure that overall latency can be decoupled from the segment duration.
@@ -26,7 +26,7 @@ Documentation
 Getting started
 ===============
 
-To enable LL-DASH mode, set the ``--is_low_latency_dash`` flag to ``true``. 
+To enable LL-DASH mode, set the ``--low_latency_dash_mode`` flag to ``true``. 
 
 All HTTP requests will use chunked transfer encoding:
 ``Transfer-Encoding: chunked``.
@@ -65,7 +65,7 @@ Configure and run packager::
         "input=${PIPE},stream=video,init_segment=${UPLOAD_URL}_init.m4s,segment_template=${UPLOAD_URL}/bigbuckbunny-video-h264-450-\$Number%04d\$.m4s" \
         --io_block_size 65536 \
         --segment_duration 2 \
-        --is_low_latency_dash=true \
+        --low_latency_dash_mode=true \
         --utc_timings "urn:mpeg:dash:utc:http-xsdate:2014"="https://time.akamai.com/?iso" \
         --mpd_output "${UPLOAD_URL}/bigbuckbunny.mpd" \
 

--- a/docs/source/tutorials/low_latency.rst
+++ b/docs/source/tutorials/low_latency.rst
@@ -11,7 +11,7 @@ If ``--low_latency_dash_mode`` is enabled, low latency DASH (LL-DASH) packaging 
 This will reduce overall latency by ensuring that the media segments are chunk encoded and delivered via an aggregating response.
 The combination of these features will ensure that overall latency can be decoupled from the segment duration.
 For low latency to be achieved, the output of Shaka Packager must be combined with a delivery system which can chain together a set of aggregating responses, such as chunked transfer encoding under HTTP/1.1 or a HTTP/2 or HTTP/3 connection.
-The output of Shaka Packager must be played DASH client which understands the availabilityTimeOffset MPD value.
+The output of Shaka Packager must be played with a DASH client that understands the availabilityTimeOffset MPD value.
 Furthermore, the player should also understand the throughput estimation and ABR challenges that arise when operating in the low latency regime.
 
 This tutorial covers LL-DASH packaging and uses features from the DASH, HTTP upload, and FFmpeg piping tutorials.

--- a/docs/source/tutorials/tutorials.rst
+++ b/docs/source/tutorials/tutorials.rst
@@ -13,3 +13,4 @@ Tutorials
    ads.rst
    ffmpeg_piping.rst
    http_upload.rst
+   low_latency.rst

--- a/packager/app/mpd_flags.cc
+++ b/packager/app/mpd_flags.cc
@@ -76,7 +76,7 @@ DEFINE_bool(dash_force_segment_list,
             "is greater than what the sidx atom allows (65535). Currently "
             "this flag is only supported in DASH ondemand profile.");
 DEFINE_bool(
-    is_low_latency_dash,
+    low_latency_dash_mode,
     false,
     "If enabled, LL-DASH streaming will be used, "
     "reducing overall latency by decoupling latency from segment duration. "

--- a/packager/app/mpd_flags.cc
+++ b/packager/app/mpd_flags.cc
@@ -75,3 +75,6 @@ DEFINE_bool(dash_force_segment_list,
             "content is huge and the total number of (sub)segment references "
             "is greater than what the sidx atom allows (65535). Currently "
             "this flag is only supported in DASH ondemand profile.");
+DEFINE_bool(is_low_latency_dash,
+            false,
+            "TODO(Caitlin): fill this out");

--- a/packager/app/mpd_flags.cc
+++ b/packager/app/mpd_flags.cc
@@ -75,9 +75,11 @@ DEFINE_bool(dash_force_segment_list,
             "content is huge and the total number of (sub)segment references "
             "is greater than what the sidx atom allows (65535). Currently "
             "this flag is only supported in DASH ondemand profile.");
-DEFINE_bool(is_low_latency_dash,
-            false,
-            "If enabled, LL-DASH streaming will be used, "
-            "reducing overall latency by decoupling latency from segment duration. "
-            "Please see https://google.github.io/shaka-packager/html/tutorials/dash.html "
-            "for more information.");
+DEFINE_bool(
+    is_low_latency_dash,
+    false,
+    "If enabled, LL-DASH streaming will be used, "
+    "reducing overall latency by decoupling latency from segment duration. "
+    "Please see "
+    "https://google.github.io/shaka-packager/html/tutorials/dash.html "
+    "for more information.");

--- a/packager/app/mpd_flags.cc
+++ b/packager/app/mpd_flags.cc
@@ -78,7 +78,6 @@ DEFINE_bool(dash_force_segment_list,
 DEFINE_bool(is_low_latency_dash,
             false,
             "If enabled, LL-DASH streaming will be used, "
-            "reducing overall latency by decoupling latency from segment duration."
-            "Chunks of data will be written to the segment file as they are created."
-            "Therefore, the content is available for playout as soon as the first chunk is uploaded, "
-            "as opposed to waiting until the entire segment is finished.");
+            "reducing overall latency by decoupling latency from segment duration. "
+            "Please see https://google.github.io/shaka-packager/html/tutorials/dash.html "
+            "for more information.");

--- a/packager/app/mpd_flags.cc
+++ b/packager/app/mpd_flags.cc
@@ -77,4 +77,8 @@ DEFINE_bool(dash_force_segment_list,
             "this flag is only supported in DASH ondemand profile.");
 DEFINE_bool(is_low_latency_dash,
             false,
-            "TODO(Caitlin): fill this out");
+            "If enabled, LL-DASH streaming will be used, "
+            "reducing overall latency by decoupling latency from segment duration."
+            "Chunks of data will be written to the segment file as they are created."
+            "Therefore, the content is available for playout as soon as the first chunk is uploaded, "
+            "as opposed to waiting until the entire segment is finished.");

--- a/packager/app/mpd_flags.cc
+++ b/packager/app/mpd_flags.cc
@@ -81,5 +81,5 @@ DEFINE_bool(
     "If enabled, LL-DASH streaming will be used, "
     "reducing overall latency by decoupling latency from segment duration. "
     "Please see "
-    "https://google.github.io/shaka-packager/html/tutorials/dash.html "
+    "https://google.github.io/shaka-packager/html/tutorials/low_latency.html "
     "for more information.");

--- a/packager/app/mpd_flags.h
+++ b/packager/app/mpd_flags.h
@@ -24,6 +24,6 @@ DECLARE_bool(allow_approximate_segment_timeline);
 DECLARE_bool(allow_codec_switching);
 DECLARE_bool(include_mspr_pro_for_playready);
 DECLARE_bool(dash_force_segment_list);
-DECLARE_bool(is_low_latency_dash);
+DECLARE_bool(low_latency_dash_mode);
 
 #endif  // APP_MPD_FLAGS_H_

--- a/packager/app/mpd_flags.h
+++ b/packager/app/mpd_flags.h
@@ -24,5 +24,6 @@ DECLARE_bool(allow_approximate_segment_timeline);
 DECLARE_bool(allow_codec_switching);
 DECLARE_bool(include_mspr_pro_for_playready);
 DECLARE_bool(dash_force_segment_list);
+DECLARE_bool(is_low_latency_dash);
 
 #endif  // APP_MPD_FLAGS_H_

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -329,19 +329,6 @@ base::Optional<PackagingParams> GetPackagingParams() {
   chunking_params.segment_sap_aligned = FLAGS_segment_sap_aligned;
   chunking_params.subsegment_sap_aligned = FLAGS_fragment_sap_aligned;
 
-  if (chunking_params.is_low_latency_dash &&
-      chunking_params.subsegment_duration_in_seconds > 0) {
-    // Low latency streaming requires data to be shipped as chunks,
-    // the smallest unit of video. Right now, each chunk contains
-    // one frame. Therefore, in low latency mode,
-    // a user specified --fragment_duration is irrelevant.
-    // TODO(caitlinocallaghan): Add a feature for users to specify the number
-    // of desired frames per chunk.
-    LOG(ERROR) << "--fragment_duration cannot be specified "
-                  "if --is_low_latency_dash is enabled.";
-    return base::nullopt;
-  }
-
   int num_key_providers = 0;
   EncryptionParams& encryption_params = packaging_params.encryption_params;
   if (FLAGS_enable_widevine_encryption) {

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -478,13 +478,6 @@ base::Optional<PackagingParams> GetPackagingParams() {
   mpd_params.include_mspr_pro = FLAGS_include_mspr_pro_for_playready;
   mpd_params.is_low_latency_dash = FLAGS_is_low_latency_dash;
 
-  if (mpd_params.is_low_latency_dash && mpd_params.utc_timings.empty()) {
-    // Low latency DASH MPD requires a UTC Timing value
-    LOG(ERROR) << "--utc_timings must be be set "
-                  "if --is_low_latency_dash is enabled.";
-    return base::nullopt;
-  }
-
   HlsParams& hls_params = packaging_params.hls_params;
   if (!GetHlsPlaylistType(FLAGS_hls_playlist_type, &hls_params.playlist_type)) {
     return base::nullopt;

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -436,6 +436,7 @@ base::Optional<PackagingParams> GetPackagingParams() {
   mp4_params.generate_sidx_in_media_segments =
       FLAGS_generate_sidx_in_media_segments;
   mp4_params.include_pssh_in_stream = FLAGS_mp4_include_pssh_in_stream;
+  mp4_params.is_low_latency_dash = FLAGS_is_low_latency_dash;
 
   packaging_params.transport_stream_timestamp_offset_ms =
       FLAGS_transport_stream_timestamp_offset_ms;

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -334,7 +334,7 @@ base::Optional<PackagingParams> GetPackagingParams() {
     // the smallest unit of video. Therefore, in low latency mode,
     // each fragment will only contain one chunk, defaulting the
     // fragment duration to the shortest time possible
-    // and making a user specified --framgnet_dration irrelevant.
+    // and making a user specified --fragment_duration irrelevant.
     LOG(ERROR) << "--fragment_duration cannot be specified "
                   "if --is_low_latency_dash is enabled.";
     return base::nullopt;

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -332,10 +332,11 @@ base::Optional<PackagingParams> GetPackagingParams() {
   if (chunking_params.is_low_latency_dash &&
       chunking_params.subsegment_duration_in_seconds > 0) {
     // Low latency streaming requires data to be shipped as chunks,
-    // the smallest unit of video. Therefore, in low latency mode,
-    // each fragment will only contain one chunk, defaulting the
-    // fragment duration to the shortest time possible
-    // and making a user specified --fragment_duration irrelevant.
+    // the smallest unit of video. Right now, each chunk contains
+    // one frame. Therefore, in low latency mode,
+    // a user specified --fragment_duration is irrelevant.
+    // TODO(caitlinocallaghan): Add a feature for users to specify the number
+    // of desired frames per chunk.
     LOG(ERROR) << "--fragment_duration cannot be specified "
                   "if --is_low_latency_dash is enabled.";
     return base::nullopt;

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -325,6 +325,7 @@ base::Optional<PackagingParams> GetPackagingParams() {
   ChunkingParams& chunking_params = packaging_params.chunking_params;
   chunking_params.segment_duration_in_seconds = FLAGS_segment_duration;
   chunking_params.subsegment_duration_in_seconds = FLAGS_fragment_duration;
+  chunking_params.is_low_latency_dash = FLAGS_is_low_latency_dash;
   chunking_params.segment_sap_aligned = FLAGS_segment_sap_aligned;
   chunking_params.subsegment_sap_aligned = FLAGS_fragment_sap_aligned;
 
@@ -474,6 +475,7 @@ base::Optional<PackagingParams> GetPackagingParams() {
       FLAGS_allow_approximate_segment_timeline;
   mpd_params.allow_codec_switching = FLAGS_allow_codec_switching;
   mpd_params.include_mspr_pro = FLAGS_include_mspr_pro_for_playready;
+  mpd_params.is_low_latency_dash = FLAGS_is_low_latency_dash;
 
   HlsParams& hls_params = packaging_params.hls_params;
   if (!GetHlsPlaylistType(FLAGS_hls_playlist_type, &hls_params.playlist_type)) {

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -491,6 +491,13 @@ base::Optional<PackagingParams> GetPackagingParams() {
   mpd_params.include_mspr_pro = FLAGS_include_mspr_pro_for_playready;
   mpd_params.is_low_latency_dash = FLAGS_is_low_latency_dash;
 
+  if (mpd_params.is_low_latency_dash && mpd_params.utc_timings.empty()) {
+    // Low latency DASH MPD requires a UTC Timing value
+    LOG(ERROR) << "--utc_timings must be be set "
+                  "if --is_low_latency_dash is enabled.";
+    return base::nullopt;
+  }
+
   HlsParams& hls_params = packaging_params.hls_params;
   if (!GetHlsPlaylistType(FLAGS_hls_playlist_type, &hls_params.playlist_type)) {
     return base::nullopt;

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -330,9 +330,13 @@ base::Optional<PackagingParams> GetPackagingParams() {
   chunking_params.subsegment_sap_aligned = FLAGS_fragment_sap_aligned;
 
   if (chunking_params.is_low_latency_dash && chunking_params.subsegment_duration_in_seconds > 0) {
-    LOG(ERROR) << "Fragment duration --fragment_duration, "
-                  "cannot be specified if LL-DASH --is_low_latency_dash, "
-                  "is enabled.";
+    // Low latency streaming requires data to be shipped as chunks,
+    // the smallest unit of video. Therefore, in low latency mode,
+    // each fragment will only contain one chunk, defaulting the
+    // fragment duration to the shortest time possible
+    // and making a user specified --framgnet_dration irrelevant.
+    LOG(ERROR) << "--fragment_duration cannot be specified "
+                  "if --is_low_latency_dash is enabled.";
     return base::nullopt;
   }
 

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -325,7 +325,7 @@ base::Optional<PackagingParams> GetPackagingParams() {
   ChunkingParams& chunking_params = packaging_params.chunking_params;
   chunking_params.segment_duration_in_seconds = FLAGS_segment_duration;
   chunking_params.subsegment_duration_in_seconds = FLAGS_fragment_duration;
-  chunking_params.is_low_latency_dash = FLAGS_is_low_latency_dash;
+  chunking_params.low_latency_dash_mode = FLAGS_low_latency_dash_mode;
   chunking_params.segment_sap_aligned = FLAGS_segment_sap_aligned;
   chunking_params.subsegment_sap_aligned = FLAGS_fragment_sap_aligned;
 
@@ -436,7 +436,7 @@ base::Optional<PackagingParams> GetPackagingParams() {
   mp4_params.generate_sidx_in_media_segments =
       FLAGS_generate_sidx_in_media_segments;
   mp4_params.include_pssh_in_stream = FLAGS_mp4_include_pssh_in_stream;
-  mp4_params.is_low_latency_dash = FLAGS_is_low_latency_dash;
+  mp4_params.low_latency_dash_mode = FLAGS_low_latency_dash_mode;
 
   packaging_params.transport_stream_timestamp_offset_ms =
       FLAGS_transport_stream_timestamp_offset_ms;
@@ -476,7 +476,7 @@ base::Optional<PackagingParams> GetPackagingParams() {
       FLAGS_allow_approximate_segment_timeline;
   mpd_params.allow_codec_switching = FLAGS_allow_codec_switching;
   mpd_params.include_mspr_pro = FLAGS_include_mspr_pro_for_playready;
-  mpd_params.is_low_latency_dash = FLAGS_is_low_latency_dash;
+  mpd_params.low_latency_dash_mode = FLAGS_low_latency_dash_mode;
 
   HlsParams& hls_params = packaging_params.hls_params;
   if (!GetHlsPlaylistType(FLAGS_hls_playlist_type, &hls_params.playlist_type)) {

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -329,6 +329,13 @@ base::Optional<PackagingParams> GetPackagingParams() {
   chunking_params.segment_sap_aligned = FLAGS_segment_sap_aligned;
   chunking_params.subsegment_sap_aligned = FLAGS_fragment_sap_aligned;
 
+  if (chunking_params.is_low_latency_dash && chunking_params.subsegment_duration_in_seconds > 0) {
+    LOG(ERROR) << "Fragment duration --fragment_duration, "
+                  "cannot be specified if LL-DASH --is_low_latency_dash, "
+                  "is enabled.";
+    return base::nullopt;
+  }
+
   int num_key_providers = 0;
   EncryptionParams& encryption_params = packaging_params.encryption_params;
   if (FLAGS_enable_widevine_encryption) {

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -329,7 +329,8 @@ base::Optional<PackagingParams> GetPackagingParams() {
   chunking_params.segment_sap_aligned = FLAGS_segment_sap_aligned;
   chunking_params.subsegment_sap_aligned = FLAGS_fragment_sap_aligned;
 
-  if (chunking_params.is_low_latency_dash && chunking_params.subsegment_duration_in_seconds > 0) {
+  if (chunking_params.is_low_latency_dash &&
+      chunking_params.subsegment_duration_in_seconds > 0) {
     // Low latency streaming requires data to be shipped as chunks,
     // the smallest unit of video. Therefore, in low latency mode,
     // each fragment will only contain one chunk, defaulting the

--- a/packager/file/file.cc
+++ b/packager/file/file.cc
@@ -17,7 +17,6 @@
 #include "packager/base/strings/stringprintf.h"
 #include "packager/file/callback_file.h"
 #include "packager/file/file_util.h"
-#include "packager/file/http_file.h"
 #include "packager/file/local_file.h"
 #include "packager/file/memory_file.h"
 #include "packager/file/threaded_io_file.h"
@@ -101,11 +100,11 @@ File* CreateUdpFile(const char* file_name, const char* mode) {
 }
 
 File* CreateHttpsFile(const char* file_name, const char* mode) {
-  return new HttpFile(HttpMethod::kPost, std::string("https://") + file_name);
+  return new HttpFile(HttpMethod::kPut, std::string("https://") + file_name);
 }
 
 File* CreateHttpFile(const char* file_name, const char* mode) {
-  return new HttpFile(HttpMethod::kPost, std::string("http://") + file_name);
+  return new HttpFile(HttpMethod::kPut, std::string("http://") + file_name);
 }
 
 File* CreateMemoryFile(const char* file_name, const char* mode) {

--- a/packager/file/file.cc
+++ b/packager/file/file.cc
@@ -17,6 +17,7 @@
 #include "packager/base/strings/stringprintf.h"
 #include "packager/file/callback_file.h"
 #include "packager/file/file_util.h"
+#include "packager/file/http_file.h"
 #include "packager/file/local_file.h"
 #include "packager/file/memory_file.h"
 #include "packager/file/threaded_io_file.h"
@@ -100,11 +101,11 @@ File* CreateUdpFile(const char* file_name, const char* mode) {
 }
 
 File* CreateHttpsFile(const char* file_name, const char* mode) {
-  return new HttpFile(HttpMethod::kPut, std::string("https://") + file_name);
+  return new HttpFile(HttpMethod::kPost, std::string("https://") + file_name);
 }
 
 File* CreateHttpFile(const char* file_name, const char* mode) {
-  return new HttpFile(HttpMethod::kPut, std::string("http://") + file_name);
+  return new HttpFile(HttpMethod::kPost, std::string("http://") + file_name);
 }
 
 File* CreateMemoryFile(const char* file_name, const char* mode) {
@@ -184,6 +185,7 @@ File* File::CreateInternalFile(const char* file_name, const char* mode) {
   base::StringPiece real_file_name;
   const FileTypeInfo* file_type = GetFileTypeInfo(file_name, &real_file_name);
   DCHECK(file_type);
+  // Calls constructor for the derived File class.
   return file_type->factory_function(real_file_name.data(), mode);
 }
 

--- a/packager/file/http_file.cc
+++ b/packager/file/http_file.cc
@@ -49,6 +49,7 @@ size_t CurlWriteCallback(char* buffer, size_t size, size_t nmemb, void* user) {
   IoCache* cache = reinterpret_cast<IoCache*>(user);
   size_t length = size * nmemb;
   if (cache) {
+    cache->Reopen();
     length = cache->Write(buffer, length);
     VLOG(3) << "CurlWriteCallback length=" << length;
   } else {
@@ -254,6 +255,7 @@ int64_t HttpFile::Size() {
 
 bool HttpFile::Flush() {
   upload_cache_.Close();
+  download_cache_.Close();
   return true;
 }
 
@@ -295,9 +297,14 @@ void HttpFile::SetupRequest() {
   curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_in_seconds_);
   curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+  CURLcode res = curl_easy_setopt(curl, CURLOPT_APPEND, 1L);
+  if (res != CURLE_OK) {
+    std::string error_message = curl_easy_strerror(res);
+    LOG(INFO) << error_message;
+  }
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &CurlWriteCallback);
   curl_easy_setopt(curl, CURLOPT_WRITEDATA,
-                   method_ == HttpMethod::kPut ? nullptr : &download_cache_);
+                method_ == HttpMethod::kPost ? nullptr : &download_cache_);
   if (method_ != HttpMethod::kGet) {
     curl_easy_setopt(curl, CURLOPT_READFUNCTION, &CurlReadCallback);
     curl_easy_setopt(curl, CURLOPT_READDATA, &upload_cache_);

--- a/packager/file/http_file.cc
+++ b/packager/file/http_file.cc
@@ -49,7 +49,6 @@ size_t CurlWriteCallback(char* buffer, size_t size, size_t nmemb, void* user) {
   IoCache* cache = reinterpret_cast<IoCache*>(user);
   size_t length = size * nmemb;
   if (cache) {
-    cache->Reopen();
     length = cache->Write(buffer, length);
     VLOG(3) << "CurlWriteCallback length=" << length;
   } else {
@@ -255,7 +254,6 @@ int64_t HttpFile::Size() {
 
 bool HttpFile::Flush() {
   upload_cache_.Close();
-  download_cache_.Close();
   return true;
 }
 
@@ -299,7 +297,7 @@ void HttpFile::SetupRequest() {
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &CurlWriteCallback);
   curl_easy_setopt(curl, CURLOPT_WRITEDATA,
-                method_ == HttpMethod::kPost ? nullptr : &download_cache_);
+                method_ == HttpMethod::kGet ? &download_cache_ : nullptr);
   if (method_ != HttpMethod::kGet) {
     curl_easy_setopt(curl, CURLOPT_READFUNCTION, &CurlReadCallback);
     curl_easy_setopt(curl, CURLOPT_READDATA, &upload_cache_);

--- a/packager/file/http_file.cc
+++ b/packager/file/http_file.cc
@@ -297,11 +297,6 @@ void HttpFile::SetupRequest() {
   curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_in_seconds_);
   curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
-  CURLcode res = curl_easy_setopt(curl, CURLOPT_APPEND, 1L);
-  if (res != CURLE_OK) {
-    std::string error_message = curl_easy_strerror(res);
-    LOG(INFO) << error_message;
-  }
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &CurlWriteCallback);
   curl_easy_setopt(curl, CURLOPT_WRITEDATA,
                 method_ == HttpMethod::kPost ? nullptr : &download_cache_);

--- a/packager/file/http_file.cc
+++ b/packager/file/http_file.cc
@@ -297,7 +297,7 @@ void HttpFile::SetupRequest() {
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &CurlWriteCallback);
   curl_easy_setopt(curl, CURLOPT_WRITEDATA,
-                method_ == HttpMethod::kGet ? &download_cache_ : nullptr);
+                   method_ == HttpMethod::kGet ? &download_cache_ : nullptr);
   if (method_ != HttpMethod::kGet) {
     curl_easy_setopt(curl, CURLOPT_READFUNCTION, &CurlReadCallback);
     curl_easy_setopt(curl, CURLOPT_READDATA, &upload_cache_);

--- a/packager/media/base/media_handler.h
+++ b/packager/media/base/media_handler.h
@@ -54,6 +54,8 @@ struct CueEvent {
 
 struct SegmentInfo {
   bool is_subsegment = false;
+  bool is_chunk = false;
+  bool is_final_chunk_in_seg = false;
   bool is_encrypted = false;
   int64_t start_timestamp = -1;
   int64_t duration = 0;

--- a/packager/media/chunking/chunking_handler.cc
+++ b/packager/media/chunking/chunking_handler.cc
@@ -114,9 +114,9 @@ Status ChunkingHandler::OnMediaSample(
   }
 
   // This handles the LL-DASH case.
-  // The subsegment index is equivalent to the chunk sequenceNumber.
-  // On each media sample, we must increment the sequenceNumber
-  // and dispatch a notification to hit FinalizeSegment() within Segmenter.
+  // On each media sample, which is the basis for a chunk, 
+  // we must increment the current_subsegment_index_
+  // in order to hit FinalizeSegment() within Segmenter.
   if (!started_new_segment && chunking_params_.is_low_latency_dash) {
     current_subsegment_index_++;
     
@@ -127,7 +127,7 @@ Status ChunkingHandler::OnMediaSample(
   // Here, a subsegment refers to a fragment that is within a segment.
   // This fragment size can be set with the 'fragment_duration' cmd arg.
   // This is NOT for the LL-DASH case.
-  if (!started_new_segment && IsSubsegmentEnabled()) {
+  if (!started_new_segment && IsSubsegmentEnabled() && !chunking_params_.is_low_latency_dash) {
     const bool can_start_new_subsegment =
         sample->is_key_frame() || !chunking_params_.subsegment_sap_aligned;
     if (can_start_new_subsegment) {

--- a/packager/media/chunking/chunking_handler.cc
+++ b/packager/media/chunking/chunking_handler.cc
@@ -117,7 +117,7 @@ Status ChunkingHandler::OnMediaSample(
   // On each media sample, which is the basis for a chunk,
   // we must increment the current_subsegment_index_
   // in order to hit FinalizeSegment() within Segmenter.
-  if (!started_new_segment && chunking_params_.is_low_latency_dash) {
+  if (!started_new_segment && chunking_params_.low_latency_dash_mode) {
     current_subsegment_index_++;
 
     RETURN_IF_ERROR(EndSubsegmentIfStarted());
@@ -128,7 +128,7 @@ Status ChunkingHandler::OnMediaSample(
   // This fragment size can be set with the 'fragment_duration' cmd arg.
   // This is NOT for the LL-DASH case.
   if (!started_new_segment && IsSubsegmentEnabled() &&
-      !chunking_params_.is_low_latency_dash) {
+      !chunking_params_.low_latency_dash_mode) {
     const bool can_start_new_subsegment =
         sample->is_key_frame() || !chunking_params_.subsegment_sap_aligned;
     if (can_start_new_subsegment) {
@@ -167,7 +167,7 @@ Status ChunkingHandler::EndSegmentIfStarted() const {
   auto segment_info = std::make_shared<SegmentInfo>();
   segment_info->start_timestamp = segment_start_time_.value();
   segment_info->duration = max_segment_time_ - segment_start_time_.value();
-  if (chunking_params_.is_low_latency_dash) {
+  if (chunking_params_.low_latency_dash_mode) {
     segment_info->is_chunk = true;
     segment_info->is_final_chunk_in_seg = true;
   }
@@ -183,7 +183,7 @@ Status ChunkingHandler::EndSubsegmentIfStarted() const {
   subsegment_info->duration =
       max_segment_time_ - subsegment_start_time_.value();
   subsegment_info->is_subsegment = true;
-  if (chunking_params_.is_low_latency_dash)
+  if (chunking_params_.low_latency_dash_mode)
     subsegment_info->is_chunk = true;
   return DispatchSegmentInfo(kStreamIndex, std::move(subsegment_info));
 }

--- a/packager/media/chunking/chunking_handler.cc
+++ b/packager/media/chunking/chunking_handler.cc
@@ -114,12 +114,12 @@ Status ChunkingHandler::OnMediaSample(
   }
 
   // This handles the LL-DASH case.
-  // On each media sample, which is the basis for a chunk, 
+  // On each media sample, which is the basis for a chunk,
   // we must increment the current_subsegment_index_
   // in order to hit FinalizeSegment() within Segmenter.
   if (!started_new_segment && chunking_params_.is_low_latency_dash) {
     current_subsegment_index_++;
-    
+
     RETURN_IF_ERROR(EndSubsegmentIfStarted());
     subsegment_start_time_ = timestamp;
   }
@@ -127,7 +127,8 @@ Status ChunkingHandler::OnMediaSample(
   // Here, a subsegment refers to a fragment that is within a segment.
   // This fragment size can be set with the 'fragment_duration' cmd arg.
   // This is NOT for the LL-DASH case.
-  if (!started_new_segment && IsSubsegmentEnabled() && !chunking_params_.is_low_latency_dash) {
+  if (!started_new_segment && IsSubsegmentEnabled() &&
+      !chunking_params_.is_low_latency_dash) {
     const bool can_start_new_subsegment =
         sample->is_key_frame() || !chunking_params_.subsegment_sap_aligned;
     if (can_start_new_subsegment) {

--- a/packager/media/chunking/chunking_handler_unittest.cc
+++ b/packager/media/chunking/chunking_handler_unittest.cc
@@ -209,7 +209,7 @@ TEST_F(ChunkingHandlerTest, CueEvent) {
 
 TEST_F(ChunkingHandlerTest, LowLatencyDash) {
   ChunkingParams chunking_params;
-  chunking_params.is_low_latency_dash = true;
+  chunking_params.low_latency_dash_mode = true;
   chunking_params.segment_duration_in_seconds = 1;
   SetUpChunkingHandler(1, chunking_params);
 

--- a/packager/media/chunking/chunking_handler_unittest.cc
+++ b/packager/media/chunking/chunking_handler_unittest.cc
@@ -207,7 +207,7 @@ TEST_F(ChunkingHandlerTest, CueEvent) {
                         kDuration, !kEncrypted, _)));
 }
 
-TEST_F(ChunkingHandlerTest, LowLatencyDash) {  
+TEST_F(ChunkingHandlerTest, LowLatencyDash) {
   ChunkingParams chunking_params;
   chunking_params.is_low_latency_dash = true;
   chunking_params.segment_duration_in_seconds = 1;
@@ -217,7 +217,8 @@ TEST_F(ChunkingHandlerTest, LowLatencyDash) {
 
   for (int i = 0; i < 1; ++i) {
     ASSERT_OK(Process(StreamData::FromMediaSample(
-        kStreamIndex, GetMediaSample(i * kChunkDurationInMs, kChunkDurationInMs, kKeyFrame))));
+        kStreamIndex, GetMediaSample(i * kChunkDurationInMs, kChunkDurationInMs,
+                                     kKeyFrame))));
   }
 
   // NOTE: Each MediaSample will create a chunk, dispatching SegmentInfo
@@ -228,15 +229,18 @@ TEST_F(ChunkingHandlerTest, LowLatencyDash) {
           IsMediaSample(kStreamIndex, 0, kChunkDurationInMs, !kEncrypted, _),
           IsSegmentInfo(kStreamIndex, 0, kChunkDurationInMs, !kIsSubsegment,
                         !kEncrypted),
-          IsMediaSample(kStreamIndex, kChunkDurationInMs, kChunkDurationInMs, !kEncrypted, _),
-          IsSegmentInfo(kStreamIndex, kChunkDurationInMs, kChunkDurationInMs, !kIsSubsegment,
-                        !kEncrypted),
-          IsMediaSample(kStreamIndex, 2 * kChunkDurationInMs, kChunkDurationInMs, !kEncrypted, _),
-          IsSegmentInfo(kStreamIndex, 2 * kChunkDurationInMs, kChunkDurationInMs, !kIsSubsegment,
-                        !kEncrypted),
-          IsMediaSample(kStreamIndex, 3 * kChunkDurationInMs, kChunkDurationInMs, !kEncrypted, _),
-          IsSegmentInfo(kStreamIndex, 3 * kChunkDurationInMs, kChunkDurationInMs, !kIsSubsegment,
-                        !kEncrypted)));
+          IsMediaSample(kStreamIndex, kChunkDurationInMs, kChunkDurationInMs,
+                        !kEncrypted, _),
+          IsSegmentInfo(kStreamIndex, kChunkDurationInMs, kChunkDurationInMs,
+                        !kIsSubsegment, !kEncrypted),
+          IsMediaSample(kStreamIndex, 2 * kChunkDurationInMs,
+                        kChunkDurationInMs, !kEncrypted, _),
+          IsSegmentInfo(kStreamIndex, 2 * kChunkDurationInMs,
+                        kChunkDurationInMs, !kIsSubsegment, !kEncrypted),
+          IsMediaSample(kStreamIndex, 3 * kChunkDurationInMs,
+                        kChunkDurationInMs, !kEncrypted, _),
+          IsSegmentInfo(kStreamIndex, 3 * kChunkDurationInMs,
+                        kChunkDurationInMs, !kIsSubsegment, !kEncrypted)));
 }
 
 }  // namespace media

--- a/packager/media/chunking/chunking_handler_unittest.cc
+++ b/packager/media/chunking/chunking_handler_unittest.cc
@@ -207,5 +207,37 @@ TEST_F(ChunkingHandlerTest, CueEvent) {
                         kDuration, !kEncrypted, _)));
 }
 
+TEST_F(ChunkingHandlerTest, LowLatencyDash) {  
+  ChunkingParams chunking_params;
+  chunking_params.is_low_latency_dash = true;
+  chunking_params.segment_duration_in_seconds = 1;
+  SetUpChunkingHandler(1, chunking_params);
+
+  const int64_t kChunkDurationInMs = 500;
+
+  for (int i = 0; i < 1; ++i) {
+    ASSERT_OK(Process(StreamData::FromMediaSample(
+        kStreamIndex, GetMediaSample(i * kChunkDurationInMs, kChunkDurationInMs, kKeyFrame))));
+  }
+
+  // NOTE: Each MediaSample will create a chunk, dispatching SegmentInfo
+  EXPECT_THAT(
+      GetOutputStreamDataVector(),
+      ElementsAre(
+          IsStreamInfo(kStreamIndex, kTimeScale0, !kEncrypted, _),
+          IsMediaSample(kStreamIndex, 0, kChunkDurationInMs, !kEncrypted, _),
+          IsSegmentInfo(kStreamIndex, 0, kChunkDurationInMs, !kIsSubsegment,
+                        !kEncrypted),
+          IsMediaSample(kStreamIndex, kChunkDurationInMs, kChunkDurationInMs, !kEncrypted, _),
+          IsSegmentInfo(kStreamIndex, kChunkDurationInMs, kChunkDurationInMs, !kIsSubsegment,
+                        !kEncrypted),
+          IsMediaSample(kStreamIndex, 2 * kChunkDurationInMs, kChunkDurationInMs, !kEncrypted, _),
+          IsSegmentInfo(kStreamIndex, 2 * kChunkDurationInMs, kChunkDurationInMs, !kIsSubsegment,
+                        !kEncrypted),
+          IsMediaSample(kStreamIndex, 3 * kChunkDurationInMs, kChunkDurationInMs, !kEncrypted, _),
+          IsSegmentInfo(kStreamIndex, 3 * kChunkDurationInMs, kChunkDurationInMs, !kIsSubsegment,
+                        !kEncrypted)));
+}
+
 }  // namespace media
 }  // namespace shaka

--- a/packager/media/chunking/chunking_handler_unittest.cc
+++ b/packager/media/chunking/chunking_handler_unittest.cc
@@ -210,7 +210,6 @@ TEST_F(ChunkingHandlerTest, CueEvent) {
 TEST_F(ChunkingHandlerTest, LowLatencyDash) {
   ChunkingParams chunking_params;
   chunking_params.is_low_latency_dash = true;
-  chunking_params.segment_duration_in_seconds = 1;
   SetUpChunkingHandler(1, chunking_params);
 
   const int64_t kChunkDurationInMs = 500;

--- a/packager/media/chunking/chunking_handler_unittest.cc
+++ b/packager/media/chunking/chunking_handler_unittest.cc
@@ -210,6 +210,7 @@ TEST_F(ChunkingHandlerTest, CueEvent) {
 TEST_F(ChunkingHandlerTest, LowLatencyDash) {
   ChunkingParams chunking_params;
   chunking_params.is_low_latency_dash = true;
+  chunking_params.segment_duration_in_seconds = 1;
   SetUpChunkingHandler(1, chunking_params);
 
   const int64_t kChunkDurationInMs = 500;

--- a/packager/media/event/combined_muxer_listener.cc
+++ b/packager/media/event/combined_muxer_listener.cc
@@ -43,6 +43,12 @@ void CombinedMuxerListener::OnMediaStart(const MuxerOptions& muxer_options,
   }
 }
 
+void CombinedMuxerListener::OnAvailabilityOffsetReady() {
+  for (auto& listener : muxer_listeners_) {
+    listener->OnAvailabilityOffsetReady();
+  }
+}
+
 void CombinedMuxerListener::OnSampleDurationReady(int32_t sample_duration) {
   for (auto& listener : muxer_listeners_) {
     listener->OnSampleDurationReady(sample_duration);

--- a/packager/media/event/combined_muxer_listener.cc
+++ b/packager/media/event/combined_muxer_listener.cc
@@ -55,6 +55,12 @@ void CombinedMuxerListener::OnSampleDurationReady(int32_t sample_duration) {
   }
 }
 
+void CombinedMuxerListener::OnSegmentDurationReady() {
+  for (auto& listener : muxer_listeners_) {
+    listener->OnSegmentDurationReady();
+  }
+}
+
 void CombinedMuxerListener::OnMediaEnd(const MediaRanges& media_ranges,
                                        float duration_seconds) {
   for (auto& listener : muxer_listeners_) {

--- a/packager/media/event/combined_muxer_listener.h
+++ b/packager/media/event/combined_muxer_listener.h
@@ -36,6 +36,7 @@ class CombinedMuxerListener : public MuxerListener {
                     const StreamInfo& stream_info,
                     int32_t time_scale,
                     ContainerType container_type) override;
+  void OnAvailabilityOffsetReady() override;
   void OnSampleDurationReady(int32_t sample_duration) override;
   void OnMediaEnd(const MediaRanges& media_ranges,
                   float duration_seconds) override;

--- a/packager/media/event/combined_muxer_listener.h
+++ b/packager/media/event/combined_muxer_listener.h
@@ -38,6 +38,7 @@ class CombinedMuxerListener : public MuxerListener {
                     ContainerType container_type) override;
   void OnAvailabilityOffsetReady() override;
   void OnSampleDurationReady(int32_t sample_duration) override;
+  void OnSegmentDurationReady() override;
   void OnMediaEnd(const MediaRanges& media_ranges,
                   float duration_seconds) override;
   void OnNewSegment(const std::string& file_name,

--- a/packager/media/event/mpd_notify_muxer_listener.cc
+++ b/packager/media/event/mpd_notify_muxer_listener.cc
@@ -105,7 +105,7 @@ void MpdNotifyMuxerListener::OnMediaStart(const MuxerOptions& muxer_options,
   }
 }
 
-// Record the availability time offset in media info for low latency mode.
+// Record the availability time offset for low latency manifests.
 void MpdNotifyMuxerListener::OnAvailabilityOffsetReady() {
   mpd_notifier_->NotifyChunkDuration(notification_id_.value());
 }
@@ -130,6 +130,11 @@ void MpdNotifyMuxerListener::OnSampleDurationReady(int32_t sample_duration) {
   }
 
   media_info_->mutable_video_info()->set_frame_duration(sample_duration);
+}
+
+// Record the segment duration for low latency manifests.
+void MpdNotifyMuxerListener::OnSegmentDurationReady() {
+  mpd_notifier_->NotifySegmentDuration(notification_id_.value());
 }
 
 void MpdNotifyMuxerListener::OnMediaEnd(const MediaRanges& media_ranges,

--- a/packager/media/event/mpd_notify_muxer_listener.cc
+++ b/packager/media/event/mpd_notify_muxer_listener.cc
@@ -105,9 +105,9 @@ void MpdNotifyMuxerListener::OnMediaStart(const MuxerOptions& muxer_options,
   }
 }
 
-// Record the availability time offset for low latency manifests.
+// Record the availability time offset for LL-DASH manifests.
 void MpdNotifyMuxerListener::OnAvailabilityOffsetReady() {
-  mpd_notifier_->NotifyChunkDuration(notification_id_.value());
+  mpd_notifier_->NotifyAvailabilityTimeOffset(notification_id_.value());
 }
 
 // Record the sample duration in the media info for VOD so that OnMediaEnd, all
@@ -132,7 +132,7 @@ void MpdNotifyMuxerListener::OnSampleDurationReady(int32_t sample_duration) {
   media_info_->mutable_video_info()->set_frame_duration(sample_duration);
 }
 
-// Record the segment duration for low latency manifests.
+// Record the segment duration for LL-DASH manifests.
 void MpdNotifyMuxerListener::OnSegmentDurationReady() {
   mpd_notifier_->NotifySegmentDuration(notification_id_.value());
 }

--- a/packager/media/event/mpd_notify_muxer_listener.cc
+++ b/packager/media/event/mpd_notify_muxer_listener.cc
@@ -105,6 +105,11 @@ void MpdNotifyMuxerListener::OnMediaStart(const MuxerOptions& muxer_options,
   }
 }
 
+// Record the availability time offset in media info for low latency mode.
+void MpdNotifyMuxerListener::OnAvailabilityOffsetReady() {
+  mpd_notifier_->NotifyChunkDuration(notification_id_.value());
+}
+
 // Record the sample duration in the media info for VOD so that OnMediaEnd, all
 // the information is in the media info.
 void MpdNotifyMuxerListener::OnSampleDurationReady(int32_t sample_duration) {

--- a/packager/media/event/mpd_notify_muxer_listener.h
+++ b/packager/media/event/mpd_notify_muxer_listener.h
@@ -44,8 +44,9 @@ class MpdNotifyMuxerListener : public MuxerListener {
                     const StreamInfo& stream_info,
                     int32_t time_scale,
                     ContainerType container_type) override;
-  void OnSampleDurationReady(int32_t sample_duration) override;
   void OnAvailabilityOffsetReady() override;
+  void OnSampleDurationReady(int32_t sample_duration) override;
+  void OnSegmentDurationReady() override;
   void OnMediaEnd(const MediaRanges& media_ranges,
                   float duration_seconds) override;
   void OnNewSegment(const std::string& file_name,

--- a/packager/media/event/mpd_notify_muxer_listener.h
+++ b/packager/media/event/mpd_notify_muxer_listener.h
@@ -45,6 +45,7 @@ class MpdNotifyMuxerListener : public MuxerListener {
                     int32_t time_scale,
                     ContainerType container_type) override;
   void OnSampleDurationReady(int32_t sample_duration) override;
+  void OnAvailabilityOffsetReady() override;
   void OnMediaEnd(const MediaRanges& media_ranges,
                   float duration_seconds) override;
   void OnNewSegment(const std::string& file_name,

--- a/packager/media/event/mpd_notify_muxer_listener_unittest.cc
+++ b/packager/media/event/mpd_notify_muxer_listener_unittest.cc
@@ -102,7 +102,7 @@ class MpdNotifyMuxerListenerTest : public ::testing::TestWithParam<MpdType> {
     mpd_options.dash_profile = DashProfile::kLive;
     // Low Latency DASH live profile should be dynamic.
     mpd_options.mpd_type = MpdType::kDynamic;
-    mpd_options.mpd_params.is_low_latency_dash = true;
+    mpd_options.mpd_params.low_latency_dash_mode = true;
     notifier_.reset(new MockMpdNotifier(mpd_options));
     listener_.reset(new MpdNotifyMuxerListener(notifier_.get()));
   }

--- a/packager/media/event/mpd_notify_muxer_listener_unittest.cc
+++ b/packager/media/event/mpd_notify_muxer_listener_unittest.cc
@@ -590,20 +590,20 @@ TEST_F(MpdNotifyMuxerListenerTest, LowLatencyDash) {
       CreateVideoStreamInfo(video_params);
 
   const std::string kExpectedMediaInfo =
-    "video_info {\n"
-    "  codec: \"avc1.010101\"\n"
-    "  width: 720\n"
-    "  height: 480\n"
-    "  time_scale: 10\n"
-    "  pixel_width: 1\n"
-    "  pixel_height: 1\n"
-    "}\n"
-    "media_duration_seconds: 20.0\n"
-    "init_segment_name: \"liveinit.mp4\"\n"
-    "segment_template: \"live-$NUMBER$.mp4\"\n"
-    "reference_time_scale: 1000\n"
-    "container_type: CONTAINER_MP4\n";
-  
+      "video_info {\n"
+      "  codec: \"avc1.010101\"\n"
+      "  width: 720\n"
+      "  height: 480\n"
+      "  time_scale: 10\n"
+      "  pixel_width: 1\n"
+      "  pixel_height: 1\n"
+      "}\n"
+      "media_duration_seconds: 20.0\n"
+      "init_segment_name: \"liveinit.mp4\"\n"
+      "segment_template: \"live-$NUMBER$.mp4\"\n"
+      "reference_time_scale: 1000\n"
+      "container_type: CONTAINER_MP4\n";
+
   const uint64_t kStartTime1 = 0u;
   const uint64_t kStartTime2 = 1001u;
   const uint64_t kDuration = 1000u;
@@ -611,10 +611,12 @@ TEST_F(MpdNotifyMuxerListenerTest, LowLatencyDash) {
   const uint64_t kSegmentSize2 = 30128u;
 
   EXPECT_CALL(*notifier_,
-            NotifyNewContainer(ExpectMediaInfoEq(kExpectedMediaInfo), _))
+              NotifyNewContainer(ExpectMediaInfoEq(kExpectedMediaInfo), _))
       .WillOnce(Return(true));
-  EXPECT_CALL(*notifier_, NotifySampleDuration(_, kDuration)).WillOnce(Return(true));
-  EXPECT_CALL(*notifier_, NotifyAvailabilityTimeOffset(_)).WillOnce(Return(true));
+  EXPECT_CALL(*notifier_, NotifySampleDuration(_, kDuration))
+      .WillOnce(Return(true));
+  EXPECT_CALL(*notifier_, NotifyAvailabilityTimeOffset(_))
+      .WillOnce(Return(true));
   EXPECT_CALL(*notifier_, NotifySegmentDuration(_)).WillOnce(Return(true));
   EXPECT_CALL(*notifier_,
               NotifyNewSegment(_, kStartTime1, kDuration, kSegmentSize1));
@@ -633,7 +635,7 @@ TEST_F(MpdNotifyMuxerListenerTest, LowLatencyDash) {
   listener_->OnCueEvent(kStartTime2, "dummy cue data");
   listener_->OnNewSegment("", kStartTime2, kDuration, kSegmentSize2);
   ::testing::Mock::VerifyAndClearExpectations(notifier_.get());
-  
+
   EXPECT_CALL(*notifier_, Flush()).Times(0);
   FireOnMediaEndWithParams(GetDefaultOnMediaEndParams());
 }

--- a/packager/media/event/muxer_listener.h
+++ b/packager/media/event/muxer_listener.h
@@ -107,7 +107,7 @@ class MuxerListener {
   /// @param sample_duration in timescale of the media.
   virtual void OnSampleDurationReady(int32_t sample_duration) = 0;
 
-  /// Called when  LL-DASH streaming starts. 
+  /// Called when LL-DASH streaming starts.
   virtual void OnSegmentDurationReady() {}
 
   /// Called when all files are written out and the muxer object does not output

--- a/packager/media/event/muxer_listener.h
+++ b/packager/media/event/muxer_listener.h
@@ -100,14 +100,14 @@ class MuxerListener {
                             int32_t time_scale,
                             ContainerType container_type) = 0;
 
-  /// Called when low latency DASH streaming starts.
+  /// Called when LL-DASH streaming starts.
   virtual void OnAvailabilityOffsetReady() {}
 
   /// Called when the average sample duration of the media is determined.
   /// @param sample_duration in timescale of the media.
   virtual void OnSampleDurationReady(int32_t sample_duration) = 0;
 
-  /// Called when low latency DASH streaming starts. 
+  /// Called when  LL-DASH streaming starts. 
   virtual void OnSegmentDurationReady() {}
 
   /// Called when all files are written out and the muxer object does not output

--- a/packager/media/event/muxer_listener.h
+++ b/packager/media/event/muxer_listener.h
@@ -100,6 +100,9 @@ class MuxerListener {
                             int32_t time_scale,
                             ContainerType container_type) = 0;
 
+  /// TODO(Caitlin): Write description
+  virtual void OnAvailabilityOffsetReady() {}
+
   /// Called when the average sample duration of the media is determined.
   /// @param sample_duration in timescale of the media.
   virtual void OnSampleDurationReady(int32_t sample_duration) = 0;

--- a/packager/media/event/muxer_listener.h
+++ b/packager/media/event/muxer_listener.h
@@ -100,12 +100,15 @@ class MuxerListener {
                             int32_t time_scale,
                             ContainerType container_type) = 0;
 
-  /// TODO(Caitlin): Write description
+  /// Called when low latency DASH streaming starts.
   virtual void OnAvailabilityOffsetReady() {}
 
   /// Called when the average sample duration of the media is determined.
   /// @param sample_duration in timescale of the media.
   virtual void OnSampleDurationReady(int32_t sample_duration) = 0;
+
+  /// Called when low latency DASH streaming starts. 
+  virtual void OnSegmentDurationReady() {}
 
   /// Called when all files are written out and the muxer object does not output
   /// any more files.

--- a/packager/media/formats/mp4/low_latency_segment_segmenter.cc
+++ b/packager/media/formats/mp4/low_latency_segment_segmenter.cc
@@ -1,0 +1,173 @@
+// Copyright 2014 Google Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+#include "packager/media/formats/mp4/low_latency_segment_segmenter.h"
+
+#include <algorithm>
+
+#include "packager/file/file.h"
+#include "packager/file/file_closer.h"
+#include "packager/media/base/buffer_writer.h"
+#include "packager/media/base/media_handler.h"
+#include "packager/media/base/muxer_options.h"
+#include "packager/media/base/muxer_util.h"
+#include "packager/media/event/muxer_listener.h"
+#include "packager/media/formats/mp4/box_definitions.h"
+#include "packager/media/formats/mp4/fragmenter.h"
+#include "packager/media/formats/mp4/key_frame_info.h"
+#include "packager/status_macros.h"
+
+namespace shaka {
+namespace media {
+namespace mp4 {
+
+LowLatencySegmentSegmenter::LowLatencySegmentSegmenter(const MuxerOptions& options,
+                                             std::unique_ptr<FileType> ftyp,
+                                             std::unique_ptr<Movie> moov)
+    : Segmenter(options, std::move(ftyp), std::move(moov)),
+      styp_(new SegmentType),
+      num_segments_(0) {
+  // Use the same brands for styp as ftyp.
+  styp_->major_brand = Segmenter::ftyp()->major_brand;
+  styp_->compatible_brands = Segmenter::ftyp()->compatible_brands;
+  // Replace 'cmfc' with 'cmfs' for CMAF segments compatibility.
+  std::replace(styp_->compatible_brands.begin(), styp_->compatible_brands.end(),
+               FOURCC_cmfc, FOURCC_cmfs);
+}
+
+LowLatencySegmentSegmenter::~LowLatencySegmentSegmenter() {}
+
+bool LowLatencySegmentSegmenter::GetInitRange(size_t* offset, size_t* size) {
+  VLOG(1) << "LowLatencySegmentSegmenter outputs init segment: "
+          << options().output_file_name;
+  return false;
+}
+
+bool LowLatencySegmentSegmenter::GetIndexRange(size_t* offset, size_t* size) {
+  VLOG(1) << "LowLatencySegmentSegmenter does not have index range.";
+  return false;
+}
+
+std::vector<Range> LowLatencySegmentSegmenter::GetSegmentRanges() {
+  VLOG(1) << "LowLatencySegmentSegmenter does not have media segment ranges.";
+  return std::vector<Range>();
+}
+
+Status LowLatencySegmentSegmenter::DoInitialize() {
+  return WriteInitSegment();
+}
+
+Status LowLatencySegmentSegmenter::DoFinalize() {
+  // Update init segment with media duration set.
+  RETURN_IF_ERROR(WriteInitSegment());
+  SetComplete();
+  return Status::OK;
+}
+
+Status LowLatencySegmentSegmenter::DoFinalizeSegment() {
+  return WriteSegment();
+}
+
+Status LowLatencySegmentSegmenter::WriteInitSegment() {
+  DCHECK(ftyp());
+  DCHECK(moov());
+  // Generate the output file with init segment.
+  std::unique_ptr<File, FileCloser> file(
+      File::Open(options().output_file_name.c_str(), "w"));
+  if (!file) {
+    return Status(error::FILE_FAILURE,
+                  "Cannot open file for write " + options().output_file_name);
+  }
+  std::unique_ptr<BufferWriter> buffer(new BufferWriter);
+  ftyp()->Write(buffer.get());
+  moov()->Write(buffer.get());
+  return buffer->WriteToFile(file.get());
+}
+
+// TODO(Caitlin): 
+// Ship each chunk off as it is created rather than
+// waiting until the entire segment is complete.
+Status LowLatencySegmentSegmenter::WriteSegment() {
+  DCHECK(sidx());
+  DCHECK(fragment_buffer());
+  DCHECK(styp_);
+  
+  DCHECK(!sidx()->references.empty());
+  // earliest_presentation_time is the earliest presentation time of any access
+  // unit in the reference stream in the first subsegment.
+  sidx()->earliest_presentation_time =
+      sidx()->references[0].earliest_presentation_time;
+
+  std::unique_ptr<BufferWriter> buffer(new BufferWriter());
+  std::unique_ptr<File, FileCloser> file;
+  std::string file_name;
+  if (options().segment_template.empty()) {
+    // Append the segment to output file if segment template is not specified.
+    file_name = options().output_file_name.c_str();
+    file.reset(File::Open(file_name.c_str(), "a"));
+    if (!file) {
+      return Status(error::FILE_FAILURE, "Cannot open file for append " +
+                                             options().output_file_name);
+    }
+  } else {
+    file_name = GetSegmentName(options().segment_template,
+                               sidx()->earliest_presentation_time,
+                               num_segments_++, options().bandwidth);
+    file.reset(File::Open(file_name.c_str(), "w"));
+    if (!file) {
+      return Status(error::FILE_FAILURE,
+                    "Cannot open file for write " + file_name);
+    }
+    styp_->Write(buffer.get());
+  }
+
+  if (options().mp4_params.generate_sidx_in_media_segments)
+    sidx()->Write(buffer.get());
+
+  const size_t segment_header_size = buffer->Size();
+  const size_t segment_size = segment_header_size + fragment_buffer()->Size();
+  DCHECK_NE(segment_size, 0u);
+
+  RETURN_IF_ERROR(buffer->WriteToFile(file.get()));
+  if (muxer_listener()) {
+    for (const KeyFrameInfo& key_frame_info : key_frame_infos()) {
+      muxer_listener()->OnKeyFrame(
+          key_frame_info.timestamp,
+          segment_header_size + key_frame_info.start_byte_offset,
+          key_frame_info.size);
+    }
+  }
+  RETURN_IF_ERROR(fragment_buffer()->WriteToFile(file.get()));
+
+  // Close the file, which also does flushing, to make sure the file is written
+  // before manifest is updated.
+  if (!file.release()->Close()) {
+    return Status(
+        error::FILE_FAILURE,
+        "Cannot close file " + file_name +
+            ", possibly file permission issue or running out of disk space.");
+  }
+
+  uint64_t segment_duration = 0;
+  // ISO/IEC 23009-1:2012: the value shall be identical to sum of the the
+  // values of all Subsegment_duration fields in the first ‘sidx’ box.
+  for (size_t i = 0; i < sidx()->references.size(); ++i)
+    segment_duration += sidx()->references[i].subsegment_duration;
+
+  UpdateProgress(segment_duration);
+  if (muxer_listener()) {
+    muxer_listener()->OnSampleDurationReady(sample_duration());
+    muxer_listener()->OnNewSegment(file_name,
+                                   sidx()->earliest_presentation_time,
+                                   segment_duration, segment_size);
+  }
+
+  return Status::OK;
+}
+
+}  // namespace mp4
+}  // namespace media
+}  // namespace shaka

--- a/packager/media/formats/mp4/low_latency_segment_segmenter.cc
+++ b/packager/media/formats/mp4/low_latency_segment_segmenter.cc
@@ -178,7 +178,6 @@ Status LowLatencySegmentSegmenter::WriteChunk() {
 
 Status LowLatencySegmentSegmenter::FinalizeSegment() {
   // Close the file now that the final chunk has been written
-  LOG(INFO) << "finalizing segment";
   if (!segment_file_.release()->Close()) {
     return Status(
         error::FILE_FAILURE,

--- a/packager/media/formats/mp4/low_latency_segment_segmenter.cc
+++ b/packager/media/formats/mp4/low_latency_segment_segmenter.cc
@@ -24,9 +24,10 @@ namespace shaka {
 namespace media {
 namespace mp4 {
 
-LowLatencySegmentSegmenter::LowLatencySegmentSegmenter(const MuxerOptions& options,
-                                             std::unique_ptr<FileType> ftyp,
-                                             std::unique_ptr<Movie> moov)
+LowLatencySegmentSegmenter::LowLatencySegmentSegmenter(
+    const MuxerOptions& options,
+    std::unique_ptr<FileType> ftyp,
+    std::unique_ptr<Movie> moov)
     : Segmenter(options, std::move(ftyp), std::move(moov)),
       styp_(new SegmentType),
       num_segments_(0) {
@@ -98,7 +99,7 @@ Status LowLatencySegmentSegmenter::WriteInitialChunk() {
   DCHECK(sidx());
   DCHECK(fragment_buffer());
   DCHECK(styp_);
-  
+
   DCHECK(!sidx()->references.empty());
   // earliest_presentation_time is the earliest presentation time of any access
   // unit in the reference stream in the first subsegment.
@@ -110,15 +111,15 @@ Status LowLatencySegmentSegmenter::WriteInitialChunk() {
     file_name_ = options().output_file_name.c_str();
   } else {
     file_name_ = GetSegmentName(options().segment_template,
-                               sidx()->earliest_presentation_time,
-                               num_segments_, options().bandwidth);
+                                sidx()->earliest_presentation_time,
+                                num_segments_, options().bandwidth);
   }
 
   // Create the segment file
   segment_file_.reset(File::Open(file_name_.c_str(), "a"));
   if (!segment_file_) {
-    return Status(error::FILE_FAILURE, "Cannot open segment file: " +
-                                            file_name_);
+    return Status(error::FILE_FAILURE,
+                  "Cannot open segment file: " + file_name_);
   }
 
   std::unique_ptr<BufferWriter> buffer(new BufferWriter());
@@ -148,13 +149,14 @@ Status LowLatencySegmentSegmenter::WriteInitialChunk() {
 
   if (muxer_listener()) {
     if (!ll_dash_mpd_values_initialized_) {
-      // Set necessary values for LL-DASH mpd after the first chunk has been processed.
+      // Set necessary values for LL-DASH mpd after the first chunk has been
+      // processed.
       muxer_listener()->OnSampleDurationReady(sample_duration());
       muxer_listener()->OnAvailabilityOffsetReady();
       muxer_listener()->OnSegmentDurationReady();
       ll_dash_mpd_values_initialized_ = true;
     }
-    // Add the current segment in the manifest. 
+    // Add the current segment in the manifest.
     // Following chunks will be appended to the open segment file.
     muxer_listener()->OnNewSegment(file_name_,
                                    sidx()->earliest_presentation_time,
@@ -185,10 +187,11 @@ Status LowLatencySegmentSegmenter::FinalizeSegment() {
             ", possibly file permission issue or running out of disk space.");
   }
 
-  // Current segment is complete. Reset state in preparation for the next segment.
+  // Current segment is complete. Reset state in preparation for the next
+  // segment.
   is_initial_chunk_in_seg_ = true;
   num_segments_++;
-  
+
   return Status::OK;
 }
 

--- a/packager/media/formats/mp4/low_latency_segment_segmenter.cc
+++ b/packager/media/formats/mp4/low_latency_segment_segmenter.cc
@@ -71,7 +71,7 @@ Status LowLatencySegmentSegmenter::DoFinalizeSegment() {
   return WriteChunk(true);
 }
 
-Status LowLatencySegmentSegmenter::DoFinalizeSubSegment() {
+Status LowLatencySegmentSegmenter::DoFinalizeChunk() {
   if (is_initial_chunk_in_seg) {
     return WriteInitialChunk();
   }

--- a/packager/media/formats/mp4/low_latency_segment_segmenter.cc
+++ b/packager/media/formats/mp4/low_latency_segment_segmenter.cc
@@ -177,7 +177,6 @@ Status LowLatencySegmentSegmenter::WriteInitialChunk() {
 }
 
 Status LowLatencySegmentSegmenter::WriteChunk() {
-  DCHECK(sidx());
   DCHECK(fragment_buffer());
 
   std::unique_ptr<File, FileCloser> file;

--- a/packager/media/formats/mp4/low_latency_segment_segmenter.cc
+++ b/packager/media/formats/mp4/low_latency_segment_segmenter.cc
@@ -213,6 +213,7 @@ Status LowLatencySegmentSegmenter::WriteSubSegment() {
           key_frame_info.size);
     }
   }
+  RETURN_IF_ERROR(fragment_buffer()->WriteToFile(file.get()));
 
   file.release();
 

--- a/packager/media/formats/mp4/low_latency_segment_segmenter.cc
+++ b/packager/media/formats/mp4/low_latency_segment_segmenter.cc
@@ -235,6 +235,10 @@ Status LowLatencySegmentSegmenter::WriteSubSegment() {
     // Add the current segment in the manifest. 
     // Following subsegments will be appended to the segment file.
     // The manifest does not need to update.
+    // TODO(Caitlin): Add logic so that sample duration and availability time offset
+    // are only set once.
+    muxer_listener()->OnSampleDurationReady(sample_duration());
+    muxer_listener()->OnAvailabilityOffsetReady();
     muxer_listener()->OnNewSegment(file_name,
                                   sidx()->earliest_presentation_time,
                                   segment_duration, segment_size);

--- a/packager/media/formats/mp4/low_latency_segment_segmenter.cc
+++ b/packager/media/formats/mp4/low_latency_segment_segmenter.cc
@@ -168,8 +168,8 @@ Status LowLatencySegmentSegmenter::WriteInitialChunk() {
     // Add the current segment in the manifest. 
     // Following chunks will be appended to the open segment file.
     muxer_listener()->OnNewSegment(file_name_,
-                                  sidx()->earliest_presentation_time,
-                                  segment_duration, segment_size);
+                                   sidx()->earliest_presentation_time,
+                                   segment_duration, segment_size);
     is_initial_chunk_in_seg_ = false;
   }
 

--- a/packager/media/formats/mp4/low_latency_segment_segmenter.h
+++ b/packager/media/formats/mp4/low_latency_segment_segmenter.h
@@ -47,7 +47,9 @@ class LowLatencySegmentSegmenter : public Segmenter {
   // Write segment to file.
   Status WriteInitSegment();
   Status WriteChunk(bool is_final_chunk);
-  Status WriteSubSegment();
+  Status WriteInitialChunk();
+
+  uint64_t GetSegmentDuration();
 
   std::unique_ptr<SegmentType> styp_;
   uint32_t num_segments_;

--- a/packager/media/formats/mp4/low_latency_segment_segmenter.h
+++ b/packager/media/formats/mp4/low_latency_segment_segmenter.h
@@ -46,12 +46,12 @@ class LowLatencySegmentSegmenter : public Segmenter {
 
   // Write segment to file.
   Status WriteInitSegment();
-  Status WriteSegment();
+  Status WriteChunk(bool is_final_chunk);
   Status WriteSubSegment();
 
   std::unique_ptr<SegmentType> styp_;
   uint32_t num_segments_;
-  bool is_first_subsegment_ = true;
+  bool is_initial_chunk_ = true;
   File* segment_file_;
 
   DISALLOW_COPY_AND_ASSIGN(LowLatencySegmentSegmenter);

--- a/packager/media/formats/mp4/low_latency_segment_segmenter.h
+++ b/packager/media/formats/mp4/low_latency_segment_segmenter.h
@@ -56,6 +56,7 @@ class LowLatencySegmentSegmenter : public Segmenter {
   bool is_initial_chunk_in_seg = true;
   bool ll_dash_mpd_values_initialized_ = false;
   File* segment_file_;
+  std::string file_name_;
 
   DISALLOW_COPY_AND_ASSIGN(LowLatencySegmentSegmenter);
 };

--- a/packager/media/formats/mp4/low_latency_segment_segmenter.h
+++ b/packager/media/formats/mp4/low_latency_segment_segmenter.h
@@ -1,0 +1,58 @@
+// Copyright 2014 Google Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+#ifndef PACKAGER_MEDIA_FORMATS_MP4_LOW_LATENCY_SEGMENT_SEGMENTER_H_
+#define PACKAGER_MEDIA_FORMATS_MP4_LOW_LATENCY_SEGMENT_SEGMENTER_H_
+
+#include "packager/media/formats/mp4/segmenter.h"
+
+namespace shaka {
+namespace media {
+namespace mp4 {
+
+struct SegmentType;
+
+/// TODO(Caitlin): Write description
+/// Segmenter for low latency DASH profiles. There will be multiple
+/// media segments, which will contain multiple fragments. The generated segments
+/// are written as they are created to files defined by 
+/// @b MuxerOptions.segment_template if specified; otherwise, the segments are 
+/// appended to the main output file specified by @b MuxerOptions.output_file_name.
+class LowLatencySegmentSegmenter : public Segmenter {
+ public:
+  LowLatencySegmentSegmenter(const MuxerOptions& options,
+                        std::unique_ptr<FileType> ftyp,
+                        std::unique_ptr<Movie> moov);
+  ~LowLatencySegmentSegmenter() override;
+
+  /// @name Segmenter implementation overrides.
+  /// @{
+  bool GetInitRange(size_t* offset, size_t* size) override;
+  bool GetIndexRange(size_t* offset, size_t* size) override;
+  std::vector<Range> GetSegmentRanges() override;
+  /// @}
+
+ private:
+  // Segmenter implementation overrides.
+  Status DoInitialize() override;
+  Status DoFinalize() override;
+  Status DoFinalizeSegment() override;
+
+  // Write segment to file.
+  Status WriteInitSegment();
+  Status WriteSegment();
+
+  std::unique_ptr<SegmentType> styp_;
+  uint32_t num_segments_;
+
+  DISALLOW_COPY_AND_ASSIGN(LowLatencySegmentSegmenter);
+};
+
+}  // namespace mp4
+}  // namespace media
+}  // namespace shaka
+
+#endif  // PACKAGER_MEDIA_FORMATS_MP4_LOW_LATENCY_SEGMENT_SEGMENTER_H_

--- a/packager/media/formats/mp4/low_latency_segment_segmenter.h
+++ b/packager/media/formats/mp4/low_latency_segment_segmenter.h
@@ -42,7 +42,7 @@ class LowLatencySegmentSegmenter : public Segmenter {
   Status DoInitialize() override;
   Status DoFinalize() override;
   Status DoFinalizeSegment() override;
-  Status DoFinalizeSubSegment() override;
+  Status DoFinalizeChunk() override;
 
   // Write segment to file.
   Status WriteInitSegment();

--- a/packager/media/formats/mp4/low_latency_segment_segmenter.h
+++ b/packager/media/formats/mp4/low_latency_segment_segmenter.h
@@ -46,14 +46,15 @@ class LowLatencySegmentSegmenter : public Segmenter {
 
   // Write segment to file.
   Status WriteInitSegment();
-  Status WriteChunk(bool is_final_chunk_in_seg);
+  Status WriteChunk();
   Status WriteInitialChunk();
+  Status FinalizeSegment();
 
   uint64_t GetSegmentDuration();
 
   std::unique_ptr<SegmentType> styp_;
   uint32_t num_segments_;
-  bool is_initial_chunk_in_seg = true;
+  bool is_initial_chunk_in_seg_ = true;
   bool ll_dash_mpd_values_initialized_ = false;
   File* segment_file_;
   std::string file_name_;

--- a/packager/media/formats/mp4/low_latency_segment_segmenter.h
+++ b/packager/media/formats/mp4/low_latency_segment_segmenter.h
@@ -19,11 +19,12 @@ namespace mp4 {
 
 struct SegmentType;
 
-/// TODO(Caitlin): Write description
-/// Segmenter for LL-DASH profiles. There will be multiple
-/// media segments, which will contain multiple fragments. The generated segments
-/// are written as they are created to files defined by 
-/// @b MuxerOptions.segment_template if specified; otherwise, the segments are 
+/// Segmenter for LL-DASH profiles. 
+/// Each segment constist of many fragments, and each fragment contains one chunk.
+/// A chunk is the smallest unit and is constructed of a single moof and mdat atom.
+/// A chunk is be generated for each recieved @b MediaSample.
+/// The generated chunks are written as they are created to files defined by 
+/// @b MuxerOptions.segment_template if specified; otherwise, the chunks are 
 /// appended to the main output file specified by @b MuxerOptions.output_file_name.
 class LowLatencySegmentSegmenter : public Segmenter {
  public:

--- a/packager/media/formats/mp4/low_latency_segment_segmenter.h
+++ b/packager/media/formats/mp4/low_latency_segment_segmenter.h
@@ -12,25 +12,25 @@
 #include "packager/file/file.h"
 #include "packager/file/file_closer.h"
 
-
 namespace shaka {
 namespace media {
 namespace mp4 {
 
 struct SegmentType;
 
-/// Segmenter for LL-DASH profiles. 
-/// Each segment constist of many fragments, and each fragment contains one chunk.
-/// A chunk is the smallest unit and is constructed of a single moof and mdat atom.
-/// A chunk is be generated for each recieved @b MediaSample.
-/// The generated chunks are written as they are created to files defined by 
-/// @b MuxerOptions.segment_template if specified; otherwise, the chunks are 
-/// appended to the main output file specified by @b MuxerOptions.output_file_name.
+/// Segmenter for LL-DASH profiles.
+/// Each segment constist of many fragments, and each fragment contains one
+/// chunk. A chunk is the smallest unit and is constructed of a single moof and
+/// mdat atom. A chunk is be generated for each recieved @b MediaSample. The
+/// generated chunks are written as they are created to files defined by
+/// @b MuxerOptions.segment_template if specified; otherwise, the chunks are
+/// appended to the main output file specified by @b
+/// MuxerOptions.output_file_name.
 class LowLatencySegmentSegmenter : public Segmenter {
  public:
   LowLatencySegmentSegmenter(const MuxerOptions& options,
-                        std::unique_ptr<FileType> ftyp,
-                        std::unique_ptr<Movie> moov);
+                             std::unique_ptr<FileType> ftyp,
+                             std::unique_ptr<Movie> moov);
   ~LowLatencySegmentSegmenter() override;
 
   /// @name Segmenter implementation overrides.

--- a/packager/media/formats/mp4/low_latency_segment_segmenter.h
+++ b/packager/media/formats/mp4/low_latency_segment_segmenter.h
@@ -40,13 +40,16 @@ class LowLatencySegmentSegmenter : public Segmenter {
   Status DoInitialize() override;
   Status DoFinalize() override;
   Status DoFinalizeSegment() override;
+  Status DoFinalizeSubSegment() override;
 
   // Write segment to file.
   Status WriteInitSegment();
   Status WriteSegment();
+  Status WriteSubSegment();
 
   std::unique_ptr<SegmentType> styp_;
   uint32_t num_segments_;
+  bool is_first_subsegment_ = true;
 
   DISALLOW_COPY_AND_ASSIGN(LowLatencySegmentSegmenter);
 };

--- a/packager/media/formats/mp4/low_latency_segment_segmenter.h
+++ b/packager/media/formats/mp4/low_latency_segment_segmenter.h
@@ -9,6 +9,8 @@
 
 #include "packager/media/formats/mp4/segmenter.h"
 
+#include "packager/file/file.h"
+
 namespace shaka {
 namespace media {
 namespace mp4 {
@@ -50,6 +52,7 @@ class LowLatencySegmentSegmenter : public Segmenter {
   std::unique_ptr<SegmentType> styp_;
   uint32_t num_segments_;
   bool is_first_subsegment_ = true;
+  File* segment_file_;
 
   DISALLOW_COPY_AND_ASSIGN(LowLatencySegmentSegmenter);
 };

--- a/packager/media/formats/mp4/low_latency_segment_segmenter.h
+++ b/packager/media/formats/mp4/low_latency_segment_segmenter.h
@@ -46,14 +46,15 @@ class LowLatencySegmentSegmenter : public Segmenter {
 
   // Write segment to file.
   Status WriteInitSegment();
-  Status WriteChunk(bool is_final_chunk);
+  Status WriteChunk(bool is_final_chunk_in_seg);
   Status WriteInitialChunk();
 
   uint64_t GetSegmentDuration();
 
   std::unique_ptr<SegmentType> styp_;
   uint32_t num_segments_;
-  bool is_initial_chunk_ = true;
+  bool is_initial_chunk_in_seg = true;
+  bool ll_dash_mpd_values_initialized_ = false;
   File* segment_file_;
 
   DISALLOW_COPY_AND_ASSIGN(LowLatencySegmentSegmenter);

--- a/packager/media/formats/mp4/low_latency_segment_segmenter.h
+++ b/packager/media/formats/mp4/low_latency_segment_segmenter.h
@@ -10,6 +10,8 @@
 #include "packager/media/formats/mp4/segmenter.h"
 
 #include "packager/file/file.h"
+#include "packager/file/file_closer.h"
+
 
 namespace shaka {
 namespace media {
@@ -56,7 +58,7 @@ class LowLatencySegmentSegmenter : public Segmenter {
   uint32_t num_segments_;
   bool is_initial_chunk_in_seg_ = true;
   bool ll_dash_mpd_values_initialized_ = false;
-  File* segment_file_;
+  std::unique_ptr<File, FileCloser> segment_file_;
   std::string file_name_;
 
   DISALLOW_COPY_AND_ASSIGN(LowLatencySegmentSegmenter);

--- a/packager/media/formats/mp4/low_latency_segment_segmenter.h
+++ b/packager/media/formats/mp4/low_latency_segment_segmenter.h
@@ -18,7 +18,7 @@ namespace mp4 {
 struct SegmentType;
 
 /// TODO(Caitlin): Write description
-/// Segmenter for low latency DASH profiles. There will be multiple
+/// Segmenter for LL-DASH profiles. There will be multiple
 /// media segments, which will contain multiple fragments. The generated segments
 /// are written as they are created to files defined by 
 /// @b MuxerOptions.segment_template if specified; otherwise, the segments are 

--- a/packager/media/formats/mp4/mp4.gyp
+++ b/packager/media/formats/mp4/mp4.gyp
@@ -29,6 +29,8 @@
         'fragmenter.cc',
         'fragmenter.h',
         'key_frame_info.h',
+        'low_latency_segment_segmenter.cc',
+        'low_latency_segment_segmenter.h',
         'mp4_media_parser.cc',
         'mp4_media_parser.h',
         'mp4_muxer.cc',

--- a/packager/media/formats/mp4/mp4_muxer.cc
+++ b/packager/media/formats/mp4/mp4_muxer.cc
@@ -22,6 +22,7 @@
 #include "packager/media/codecs/es_descriptor.h"
 #include "packager/media/event/muxer_listener.h"
 #include "packager/media/formats/mp4/box_definitions.h"
+#include "packager/media/formats/mp4/low_latency_segment_segmenter.h"
 #include "packager/media/formats/mp4/multi_segment_segmenter.h"
 #include "packager/media/formats/mp4/single_segment_segmenter.h"
 #include "packager/media/formats/ttml/ttml_generator.h"
@@ -298,6 +299,9 @@ Status MP4Muxer::DelayInitializeMuxer() {
   if (options().segment_template.empty()) {
     segmenter_.reset(new SingleSegmentSegmenter(options(), std::move(ftyp),
                                                 std::move(moov)));
+  } else if (options().mp4_params.is_low_latency_dash) {
+    segmenter_.reset(
+        new LowLatencySegmentSegmenter(options(), std::move(ftyp), std::move(moov)));
   } else {
     segmenter_.reset(
         new MultiSegmentSegmenter(options(), std::move(ftyp), std::move(moov)));

--- a/packager/media/formats/mp4/mp4_muxer.cc
+++ b/packager/media/formats/mp4/mp4_muxer.cc
@@ -299,7 +299,7 @@ Status MP4Muxer::DelayInitializeMuxer() {
   if (options().segment_template.empty()) {
     segmenter_.reset(new SingleSegmentSegmenter(options(), std::move(ftyp),
                                                 std::move(moov)));
-  } else if (options().mp4_params.is_low_latency_dash) {
+  } else if (options().mp4_params.low_latency_dash_mode) {
     segmenter_.reset(new LowLatencySegmentSegmenter(options(), std::move(ftyp),
                                                     std::move(moov)));
   } else {

--- a/packager/media/formats/mp4/mp4_muxer.cc
+++ b/packager/media/formats/mp4/mp4_muxer.cc
@@ -300,8 +300,8 @@ Status MP4Muxer::DelayInitializeMuxer() {
     segmenter_.reset(new SingleSegmentSegmenter(options(), std::move(ftyp),
                                                 std::move(moov)));
   } else if (options().mp4_params.is_low_latency_dash) {
-    segmenter_.reset(
-        new LowLatencySegmentSegmenter(options(), std::move(ftyp), std::move(moov)));
+    segmenter_.reset(new LowLatencySegmentSegmenter(options(), std::move(ftyp),
+                                                    std::move(moov)));
   } else {
     segmenter_.reset(
         new MultiSegmentSegmenter(options(), std::move(ftyp), std::move(moov)));

--- a/packager/media/formats/mp4/segmenter.cc
+++ b/packager/media/formats/mp4/segmenter.cc
@@ -240,7 +240,7 @@ Status Segmenter::FinalizeSegment(size_t stream_id,
     sidx_->references.clear();
     key_frame_infos_.clear();
     return status;
-  } 
+  }
   return Status::OK;
 }
 

--- a/packager/media/formats/mp4/segmenter.cc
+++ b/packager/media/formats/mp4/segmenter.cc
@@ -226,14 +226,19 @@ Status Segmenter::FinalizeSegment(size_t stream_id,
   for (std::unique_ptr<Fragmenter>& fragmenter : fragmenters_)
     fragmenter->ClearFragmentFinalized();
   if (!segment_info.is_subsegment) {
+    // NOTE: The final chunk in a Low Latency segment marks the end of 
+    // a segment and is NOT classified as a subsegment.
+    // Thus, it will trigger DoFinalizeSegment.
+
+    // Finalize the segment.
     Status status = DoFinalizeSegment();
     // Reset segment information to initial state.
     sidx_->references.clear();
     key_frame_infos_.clear();
     return status;
   } else if (options_.mp4_params.is_low_latency_dash) {
-    // Finalize the finished chunk for the low latency case
-    return DoFinalizeSubSegment();
+    // Finalize the completed chunk for the Low Latency case.
+    return DoFinalizeChunk();
   }
   return Status::OK;
 }

--- a/packager/media/formats/mp4/segmenter.cc
+++ b/packager/media/formats/mp4/segmenter.cc
@@ -225,7 +225,7 @@ Status Segmenter::FinalizeSegment(size_t stream_id,
 
   for (std::unique_ptr<Fragmenter>& fragmenter : fragmenters_)
     fragmenter->ClearFragmentFinalized();
-    
+
   if (segment_info.is_chunk) {
     // Finalize the completed chunk for the LL-DASH case.
     Status status = DoFinalizeChunk();

--- a/packager/media/formats/mp4/segmenter.cc
+++ b/packager/media/formats/mp4/segmenter.cc
@@ -225,21 +225,22 @@ Status Segmenter::FinalizeSegment(size_t stream_id,
 
   for (std::unique_ptr<Fragmenter>& fragmenter : fragmenters_)
     fragmenter->ClearFragmentFinalized();
-  if (!segment_info.is_subsegment) {
-    // NOTE: The final chunk in a Low Latency segment marks the end of 
-    // a segment and is NOT classified as a subsegment.
-    // Thus, it will trigger DoFinalizeSegment.
+    
+  if (segment_info.is_chunk) {
+    // Finalize the completed chunk for the LL-DASH case.
+    Status status = DoFinalizeChunk();
+    if (!status.ok())
+      return status;
+  }
 
+  if (!segment_info.is_subsegment || segment_info.is_final_chunk_in_seg) {
     // Finalize the segment.
     Status status = DoFinalizeSegment();
     // Reset segment information to initial state.
     sidx_->references.clear();
     key_frame_infos_.clear();
     return status;
-  } else if (options_.mp4_params.is_low_latency_dash) {
-    // Finalize the completed chunk for the Low Latency case.
-    return DoFinalizeChunk();
-  }
+  } 
   return Status::OK;
 }
 

--- a/packager/media/formats/mp4/segmenter.cc
+++ b/packager/media/formats/mp4/segmenter.cc
@@ -231,6 +231,9 @@ Status Segmenter::FinalizeSegment(size_t stream_id,
     sidx_->references.clear();
     key_frame_infos_.clear();
     return status;
+  } else if (options_.mp4_params.is_low_latency_dash) {
+    // Finalize the finished chunk for the low latency case
+    return DoFinalizeSubSegment();
   }
   return Status::OK;
 }

--- a/packager/media/formats/mp4/segmenter.h
+++ b/packager/media/formats/mp4/segmenter.h
@@ -126,7 +126,7 @@ class Segmenter {
   virtual Status DoFinalize() = 0;
   virtual Status DoFinalizeSegment() = 0;
 
-  virtual Status DoFinalizeSubSegment() { return Status::OK; }
+  virtual Status DoFinalizeChunk() { return Status::OK; }
 
   uint32_t GetReferenceStreamId();
 

--- a/packager/media/formats/mp4/segmenter.h
+++ b/packager/media/formats/mp4/segmenter.h
@@ -126,6 +126,8 @@ class Segmenter {
   virtual Status DoFinalize() = 0;
   virtual Status DoFinalizeSegment() = 0;
 
+  virtual Status DoFinalizeSubSegment() { return Status::OK; }
+
   uint32_t GetReferenceStreamId();
 
   void FinalizeFragmentForKeyRotation(

--- a/packager/media/public/chunking_params.h
+++ b/packager/media/public/chunking_params.h
@@ -25,11 +25,11 @@ struct ChunkingParams {
   /// Setting to subsegment_sap_aligned to true but segment_sap_aligned to false
   /// is not allowed.
   bool subsegment_sap_aligned = true;
-  /// Enable LL-DASH streaming. 
-  /// Each segment constists of many fragments, and each fragment contains one chunk.
-  /// A chunk is the smallest unit and is constructed of a single moof and mdat atom.
-  /// Each chunk is uploaded immediately upon creation,
-  /// decoupling latency from segment duration. 
+  /// Enable LL-DASH streaming.
+  /// Each segment constists of many fragments, and each fragment contains one
+  /// chunk. A chunk is the smallest unit and is constructed of a single moof
+  /// and mdat atom. Each chunk is uploaded immediately upon creation,
+  /// decoupling latency from segment duration.
   bool is_low_latency_dash = false;
 };
 

--- a/packager/media/public/chunking_params.h
+++ b/packager/media/public/chunking_params.h
@@ -25,8 +25,11 @@ struct ChunkingParams {
   /// Setting to subsegment_sap_aligned to true but segment_sap_aligned to false
   /// is not allowed.
   bool subsegment_sap_aligned = true;
-  /// Enable LL-DASH streaming
-  /// TODO(Caitlin): Elaborate
+  /// Enable LL-DASH streaming. 
+  /// Each segment constists of many fragments, and each fragment contains one chunk.
+  /// A chunk is the smallest unit and is constructed of a single moof and mdat atom.
+  /// Each chunk is uploaded immediately upon creation,
+  /// decoupling latency from segment duration. 
   bool is_low_latency_dash = false;
 };
 

--- a/packager/media/public/chunking_params.h
+++ b/packager/media/public/chunking_params.h
@@ -25,6 +25,9 @@ struct ChunkingParams {
   /// Setting to subsegment_sap_aligned to true but segment_sap_aligned to false
   /// is not allowed.
   bool subsegment_sap_aligned = true;
+  /// Use low latency dash streaming
+  /// TODO(Caitlin): Elaborate
+  bool is_low_latency_dash = false;
 };
 
 }  // namespace shaka

--- a/packager/media/public/chunking_params.h
+++ b/packager/media/public/chunking_params.h
@@ -30,7 +30,7 @@ struct ChunkingParams {
   /// chunk. A chunk is the smallest unit and is constructed of a single moof
   /// and mdat atom. Each chunk is uploaded immediately upon creation,
   /// decoupling latency from segment duration.
-  bool is_low_latency_dash = false;
+  bool low_latency_dash_mode = false;
 };
 
 }  // namespace shaka

--- a/packager/media/public/chunking_params.h
+++ b/packager/media/public/chunking_params.h
@@ -25,7 +25,7 @@ struct ChunkingParams {
   /// Setting to subsegment_sap_aligned to true but segment_sap_aligned to false
   /// is not allowed.
   bool subsegment_sap_aligned = true;
-  /// Use low latency dash streaming
+  /// Enable LL-DASH streaming
   /// TODO(Caitlin): Elaborate
   bool is_low_latency_dash = false;
 };

--- a/packager/media/public/mp4_output_params.h
+++ b/packager/media/public/mp4_output_params.h
@@ -20,8 +20,8 @@ struct Mp4OutputParams {
   /// Note that it is required by spec if segment_template contains $Times$
   /// specifier.
   bool generate_sidx_in_media_segments = true;
-
-  /// TODO(Caitlin): Add description
+  /// Enable LL-DASH streaming
+  /// TODO(Caitlin): Elaborate
   bool is_low_latency_dash = false;
 };
 

--- a/packager/media/public/mp4_output_params.h
+++ b/packager/media/public/mp4_output_params.h
@@ -25,7 +25,7 @@ struct Mp4OutputParams {
   /// chunk. A chunk is the smallest unit and is constructed of a single moof
   /// and mdat atom. Each chunk is uploaded immediately upon creation,
   /// decoupling latency from segment duration.
-  bool is_low_latency_dash = false;
+  bool low_latency_dash_mode = false;
 };
 
 }  // namespace shaka

--- a/packager/media/public/mp4_output_params.h
+++ b/packager/media/public/mp4_output_params.h
@@ -20,8 +20,11 @@ struct Mp4OutputParams {
   /// Note that it is required by spec if segment_template contains $Times$
   /// specifier.
   bool generate_sidx_in_media_segments = true;
-  /// Enable LL-DASH streaming
-  /// TODO(Caitlin): Elaborate
+  /// Enable LL-DASH streaming. 
+  /// Each segment constists of many fragments, and each fragment contains one chunk.
+  /// A chunk is the smallest unit and is constructed of a single moof and mdat atom.
+  /// Each chunk is uploaded immediately upon creation,
+  /// decoupling latency from segment duration. 
   bool is_low_latency_dash = false;
 };
 

--- a/packager/media/public/mp4_output_params.h
+++ b/packager/media/public/mp4_output_params.h
@@ -20,11 +20,11 @@ struct Mp4OutputParams {
   /// Note that it is required by spec if segment_template contains $Times$
   /// specifier.
   bool generate_sidx_in_media_segments = true;
-  /// Enable LL-DASH streaming. 
-  /// Each segment constists of many fragments, and each fragment contains one chunk.
-  /// A chunk is the smallest unit and is constructed of a single moof and mdat atom.
-  /// Each chunk is uploaded immediately upon creation,
-  /// decoupling latency from segment duration. 
+  /// Enable LL-DASH streaming.
+  /// Each segment constists of many fragments, and each fragment contains one
+  /// chunk. A chunk is the smallest unit and is constructed of a single moof
+  /// and mdat atom. Each chunk is uploaded immediately upon creation,
+  /// decoupling latency from segment duration.
   bool is_low_latency_dash = false;
 };
 

--- a/packager/media/public/mp4_output_params.h
+++ b/packager/media/public/mp4_output_params.h
@@ -20,6 +20,9 @@ struct Mp4OutputParams {
   /// Note that it is required by spec if segment_template contains $Times$
   /// specifier.
   bool generate_sidx_in_media_segments = true;
+
+  /// TODO(Caitlin): Add description
+  bool is_low_latency_dash = false;
 };
 
 }  // namespace shaka

--- a/packager/mpd/base/media_info.proto
+++ b/packager/mpd/base/media_info.proto
@@ -207,7 +207,7 @@ message MediaInfo {
 
   // LOW LATENCY DASH only. Defines the availabilityTimeOffset in seconds.
   // Equal to the segment time minus the chunk duration.
-  optional float availability_time_offset = 24;
+  optional double availability_time_offset = 24;
   // LOW LATENCY DASH only. Defines the segment duration
   // with respect to the reference time scale.
   // Equal to the target segment duration times the reference time scale.

--- a/packager/mpd/base/media_info.proto
+++ b/packager/mpd/base/media_info.proto
@@ -204,4 +204,9 @@ message MediaInfo {
   // Role value defined in "urn:mpeg:dash:role:2011" scheme or in the format:
   // scheme_id_uri=value (to be implemented).
   repeated string dash_roles = 22;
+
+  // LOW LATENCY DASH only. Defines the availabilityTimeOffset in seconds.
+  // TODO(Caitlin): improve description.
+  // Equal to the segment time minus the chunk duration.
+  optional float availability_time_offset = 24;
 }

--- a/packager/mpd/base/media_info.proto
+++ b/packager/mpd/base/media_info.proto
@@ -206,7 +206,6 @@ message MediaInfo {
   repeated string dash_roles = 22;
 
   // LOW LATENCY DASH only. Defines the availabilityTimeOffset in seconds.
-  // TODO(Caitlin): improve description.
   // Equal to the segment time minus the chunk duration.
   optional float availability_time_offset = 24;
   // LOW LATENCY DASH only. Defines the segment duration

--- a/packager/mpd/base/media_info.proto
+++ b/packager/mpd/base/media_info.proto
@@ -209,4 +209,8 @@ message MediaInfo {
   // TODO(Caitlin): improve description.
   // Equal to the segment time minus the chunk duration.
   optional float availability_time_offset = 24;
+  // LOW LATENCY DASH only. Defines the segment duration
+  // with respect to the reference time scale.
+  // Equal to the target segment duration times the reference time scale.
+  optional uint64 segment_duration = 25;
 }

--- a/packager/mpd/base/mock_mpd_builder.h
+++ b/packager/mpd/base/mock_mpd_builder.h
@@ -77,6 +77,7 @@ class MockRepresentation : public Representation {
                void(const std::string& drm_uuid, const std::string& pssh));
   MOCK_METHOD3(AddNewSegment,
                void(int64_t start_time, int64_t duration, uint64_t size));
+  MOCK_METHOD0(SetSegmentDuration, void());
   MOCK_METHOD1(SetSampleDuration, void(int32_t sample_duration));
   MOCK_CONST_METHOD0(GetMediaInfo, const MediaInfo&());
 };

--- a/packager/mpd/base/mock_mpd_builder.h
+++ b/packager/mpd/base/mock_mpd_builder.h
@@ -78,6 +78,7 @@ class MockRepresentation : public Representation {
   MOCK_METHOD3(AddNewSegment,
                void(int64_t start_time, int64_t duration, uint64_t size));
   MOCK_METHOD0(SetSegmentDuration, void());
+  MOCK_METHOD0(SetAvailabilityTimeOffset, void());
   MOCK_METHOD1(SetSampleDuration, void(int32_t sample_duration));
   MOCK_CONST_METHOD0(GetMediaInfo, const MediaInfo&());
 };

--- a/packager/mpd/base/mock_mpd_notifier.h
+++ b/packager/mpd/base/mock_mpd_notifier.h
@@ -31,6 +31,8 @@ class MockMpdNotifier : public MpdNotifier {
                     int64_t start_time,
                     int64_t duration,
                     uint64_t size));
+  MOCK_METHOD1(NotifyAvailabilityTimeOffset, bool(uint32_t container_id));
+  MOCK_METHOD1(NotifySegmentDuration, bool(uint32_t container_id));
   MOCK_METHOD2(NotifyCueEvent, bool(uint32_t container_id, int64_t timestamp));
   MOCK_METHOD4(NotifyEncryptionUpdate,
                bool(uint32_t container_id,

--- a/packager/mpd/base/mpd_builder.cc
+++ b/packager/mpd/base/mpd_builder.cc
@@ -279,10 +279,6 @@ bool MpdBuilder::AddDynamicMpdInfo(XmlNode* mpd_node) {
   RCHECK(mpd_node->SetStringAttribute(
       "publishTime", XmlDateTimeNowWithOffset(0, clock_.get())));
 
-  // std::string val;
-  // mpd_node->GetAttribute("publishTime", &val);
-  // LOG(INFO) << "PUBLISH TIME!!!! " << val;
-
   // 'availabilityStartTime' is required for dynamic profile. Calculate if
   // not already calculated.
   if (availability_start_time_.empty()) {

--- a/packager/mpd/base/mpd_builder.cc
+++ b/packager/mpd/base/mpd_builder.cc
@@ -318,19 +318,6 @@ bool MpdBuilder::AddDynamicMpdInfo(XmlNode* mpd_node) {
                        mpd_node);
 }
 
-// ServiceDescription
-// bool MpdBuilder::AddServiceDescription(XmlNode* mpd_node) {
-//   DCHECK(mpd_node);
-//   DCHECK_EQ(MpdType::kDynamic, mpd_options_.mpd_type);
-
-//   XmlNode service_description_node("ServiceDescription");
-//   RCHECK(service_description_node.SetIntegerAttribute("id", 0));
-//   RCHECK(mpd_node->AddChild(std::move(service_description_node)));
-
-//   return true;
-
-// }
-
 bool MpdBuilder::AddUtcTiming(XmlNode* mpd_node) {
   DCHECK(mpd_node);
   DCHECK_EQ(MpdType::kDynamic, mpd_options_.mpd_type);

--- a/packager/mpd/base/mpd_builder.cc
+++ b/packager/mpd/base/mpd_builder.cc
@@ -279,6 +279,10 @@ bool MpdBuilder::AddDynamicMpdInfo(XmlNode* mpd_node) {
   RCHECK(mpd_node->SetStringAttribute(
       "publishTime", XmlDateTimeNowWithOffset(0, clock_.get())));
 
+  // std::string val;
+  // mpd_node->GetAttribute("publishTime", &val);
+  // LOG(INFO) << "PUBLISH TIME!!!! " << val;
+
   // 'availabilityStartTime' is required for dynamic profile. Calculate if
   // not already calculated.
   if (availability_start_time_.empty()) {
@@ -313,6 +317,19 @@ bool MpdBuilder::AddDynamicMpdInfo(XmlNode* mpd_node) {
                        mpd_options_.mpd_params.suggested_presentation_delay,
                        mpd_node);
 }
+
+// ServiceDescription
+// bool MpdBuilder::AddServiceDescription(XmlNode* mpd_node) {
+//   DCHECK(mpd_node);
+//   DCHECK_EQ(MpdType::kDynamic, mpd_options_.mpd_type);
+
+//   XmlNode service_description_node("ServiceDescription");
+//   RCHECK(service_description_node.SetIntegerAttribute("id", 0));
+//   RCHECK(mpd_node->AddChild(std::move(service_description_node)));
+
+//   return true;
+
+// }
 
 bool MpdBuilder::AddUtcTiming(XmlNode* mpd_node) {
   DCHECK(mpd_node);

--- a/packager/mpd/base/mpd_notifier.h
+++ b/packager/mpd/base/mpd_notifier.h
@@ -46,12 +46,12 @@ class MpdNotifier {
   virtual bool NotifyNewContainer(const MediaInfo& media_info,
                                   uint32_t* container_id) = 0;
 
-  /// Record the duration of a single chunk for Low Latency DASH streaming.
+  /// Record the availailityTimeOffset for Low Latency DASH streaming.
   /// @param container_id Container ID obtained from calling
   ///        NotifyNewContainer().
   /// @return true on success, false otherwise. This may fail if the container
   ///         specified by @a container_id does not exist.
-  virtual bool NotifyChunkDuration(uint32_t container_id) {return true;}
+  virtual bool NotifyAvailabilityTimeOffset(uint32_t container_id) {return true;}
 
   /// Change the sample duration of container with @a container_id.
   /// @param container_id Container ID obtained from calling

--- a/packager/mpd/base/mpd_notifier.h
+++ b/packager/mpd/base/mpd_notifier.h
@@ -51,7 +51,9 @@ class MpdNotifier {
   ///        NotifyNewContainer().
   /// @return true on success, false otherwise. This may fail if the container
   ///         specified by @a container_id does not exist.
-  virtual bool NotifyAvailabilityTimeOffset(uint32_t container_id) {return true;}
+  virtual bool NotifyAvailabilityTimeOffset(uint32_t container_id) {
+    return true;
+  }
 
   /// Change the sample duration of container with @a container_id.
   /// @param container_id Container ID obtained from calling
@@ -68,7 +70,7 @@ class MpdNotifier {
   ///        NotifyNewContainer().
   /// @return true on success, false otherwise. This may fail if the container
   ///         specified by @a container_id does not exist.
-  virtual bool NotifySegmentDuration(uint32_t container_id) {return true;}
+  virtual bool NotifySegmentDuration(uint32_t container_id) { return true; }
 
   /// Notifies MpdBuilder that there is a new segment ready. For live, this
   /// is usually a new segment, for VOD this is usually a subsegment.

--- a/packager/mpd/base/mpd_notifier.h
+++ b/packager/mpd/base/mpd_notifier.h
@@ -46,6 +46,9 @@ class MpdNotifier {
   virtual bool NotifyNewContainer(const MediaInfo& media_info,
                                   uint32_t* container_id) = 0;
 
+  /// TODO:(Caitlin): write description
+  virtual bool NotifyChunkDuration(uint32_t container_id) {return true;}
+
   /// Change the sample duration of container with @a container_id.
   /// @param container_id Container ID obtained from calling
   ///        NotifyNewContainer().

--- a/packager/mpd/base/mpd_notifier.h
+++ b/packager/mpd/base/mpd_notifier.h
@@ -132,11 +132,6 @@ class MpdNotifier {
     return mpd_options_.mpd_params.use_segment_list;
   }
 
-  /// @return The value of target_segment_duration flag
-  double target_segment_duration() const {
-    return mpd_options_.mpd_params.target_segment_duration;
-  }
-
  private:
   const MpdOptions mpd_options_;
 

--- a/packager/mpd/base/mpd_notifier.h
+++ b/packager/mpd/base/mpd_notifier.h
@@ -46,7 +46,11 @@ class MpdNotifier {
   virtual bool NotifyNewContainer(const MediaInfo& media_info,
                                   uint32_t* container_id) = 0;
 
-  /// TODO:(Caitlin): write description
+  /// Record the duration of a single chunk for Low Latency DASH streaming.
+  /// @param container_id Container ID obtained from calling
+  ///        NotifyNewContainer().
+  /// @return true on success, false otherwise. This may fail if the container
+  ///         specified by @a container_id does not exist.
   virtual bool NotifyChunkDuration(uint32_t container_id) {return true;}
 
   /// Change the sample duration of container with @a container_id.
@@ -58,6 +62,13 @@ class MpdNotifier {
   ///         specified by @a container_id does not exist.
   virtual bool NotifySampleDuration(uint32_t container_id,
                                     int32_t sample_duration) = 0;
+
+  /// Record the duration of a segment for Low Latency DASH streaming.
+  /// @param container_id Container ID obtained from calling
+  ///        NotifyNewContainer().
+  /// @return true on success, false otherwise. This may fail if the container
+  ///         specified by @a container_id does not exist.
+  virtual bool NotifySegmentDuration(uint32_t container_id) {return true;}
 
   /// Notifies MpdBuilder that there is a new segment ready. For live, this
   /// is usually a new segment, for VOD this is usually a subsegment.
@@ -119,6 +130,11 @@ class MpdNotifier {
   /// @return The value of dash_force_segment_list flag
   bool use_segment_list() const {
     return mpd_options_.mpd_params.use_segment_list;
+  }
+
+  /// @return The value of target_segment_duration flag
+  double target_segment_duration() const {
+    return mpd_options_.mpd_params.target_segment_duration;
   }
 
  private:

--- a/packager/mpd/base/period.cc
+++ b/packager/mpd/base/period.cc
@@ -137,18 +137,25 @@ base::Optional<xml::XmlNode> Period::GetXml(bool output_period_duration) {
   if (!period.SetId(id_))
     return base::nullopt;
 
-  // insert ServiceDescription into Period section 
-  // xml::XmlNode service_description_node("ServiceDescription");
-  // if (!service_description_node.SetIntegerAttribute("id", 0))
-  //   return base::nullopt;
-  // xml::XmlNode latency_node("Latency");
-  // if (!latency_node.SetIntegerAttribute("target", 3500))
-  //   return base::nullopt;
-  // if (!service_description_node.AddChild(std::move(latency_node)))
-  //   return base::nullopt;
-  // if (!period.AddChild(std::move(service_description_node)))
-  //   return base::nullopt;
-  
+  // Required for LL-DASH MPDs.
+  if (mpd_options_.mpd_params.is_low_latency_dash) {
+    // Create ServiceDescription element. 
+    xml::XmlNode service_description_node("ServiceDescription");
+    if (!service_description_node.SetIntegerAttribute("id", id_))
+      return base::nullopt;
+    
+    // Insert Latency into ServiceDescription element. 
+    xml::XmlNode latency_node("Latency");
+    uint64_t target_latency_ms = mpd_options_.mpd_params.target_latency_seconds * 1000;
+    if (!latency_node.SetIntegerAttribute("target", target_latency_ms))
+      return base::nullopt;
+    if (!service_description_node.AddChild(std::move(latency_node)))
+      return base::nullopt;
+    
+    // Insert ServiceDescription into Period element. 
+    if (!period.AddChild(std::move(service_description_node)))
+      return base::nullopt;
+  }
 
   // Iterate thru AdaptationSets and add them to one big Period element.
   for (const auto& adaptation_set : adaptation_sets_) {

--- a/packager/mpd/base/period.cc
+++ b/packager/mpd/base/period.cc
@@ -136,6 +136,20 @@ base::Optional<xml::XmlNode> Period::GetXml(bool output_period_duration) {
   // Required for 'dynamic' MPDs.
   if (!period.SetId(id_))
     return base::nullopt;
+
+  // insert ServiceDescription into Period section 
+  // xml::XmlNode service_description_node("ServiceDescription");
+  // if (!service_description_node.SetIntegerAttribute("id", 0))
+  //   return base::nullopt;
+  // xml::XmlNode latency_node("Latency");
+  // if (!latency_node.SetIntegerAttribute("target", 3500))
+  //   return base::nullopt;
+  // if (!service_description_node.AddChild(std::move(latency_node)))
+  //   return base::nullopt;
+  // if (!period.AddChild(std::move(service_description_node)))
+  //   return base::nullopt;
+  
+
   // Iterate thru AdaptationSets and add them to one big Period element.
   for (const auto& adaptation_set : adaptation_sets_) {
     auto child = adaptation_set->GetXml();

--- a/packager/mpd/base/period.cc
+++ b/packager/mpd/base/period.cc
@@ -138,7 +138,7 @@ base::Optional<xml::XmlNode> Period::GetXml(bool output_period_duration) {
     return base::nullopt;
 
   // Required for LL-DASH MPDs.
-  if (mpd_options_.mpd_params.is_low_latency_dash) {
+  if (mpd_options_.mpd_params.low_latency_dash_mode) {
     // Create ServiceDescription element.
     xml::XmlNode service_description_node("ServiceDescription");
     if (!service_description_node.SetIntegerAttribute("id", id_))

--- a/packager/mpd/base/period.cc
+++ b/packager/mpd/base/period.cc
@@ -139,20 +139,21 @@ base::Optional<xml::XmlNode> Period::GetXml(bool output_period_duration) {
 
   // Required for LL-DASH MPDs.
   if (mpd_options_.mpd_params.is_low_latency_dash) {
-    // Create ServiceDescription element. 
+    // Create ServiceDescription element.
     xml::XmlNode service_description_node("ServiceDescription");
     if (!service_description_node.SetIntegerAttribute("id", id_))
       return base::nullopt;
-    
-    // Insert Latency into ServiceDescription element. 
+
+    // Insert Latency into ServiceDescription element.
     xml::XmlNode latency_node("Latency");
-    uint64_t target_latency_ms = mpd_options_.mpd_params.target_latency_seconds * 1000;
+    uint64_t target_latency_ms =
+        mpd_options_.mpd_params.target_latency_seconds * 1000;
     if (!latency_node.SetIntegerAttribute("target", target_latency_ms))
       return base::nullopt;
     if (!service_description_node.AddChild(std::move(latency_node)))
       return base::nullopt;
-    
-    // Insert ServiceDescription into Period element. 
+
+    // Insert ServiceDescription into Period element.
     if (!period.AddChild(std::move(service_description_node)))
       return base::nullopt;
   }

--- a/packager/mpd/base/period_unittest.cc
+++ b/packager/mpd/base/period_unittest.cc
@@ -201,7 +201,8 @@ TEST_F(PeriodTest, LowLatencyDashMpdGetXml) {
       "<Period id=\"9\" start=\"PT5.6S\">"
       // LL-DASH standards require ServiceDescription and Latency elements
       "  <ServiceDescription id=\"9\" >"
-      // In LL-DASH MPD, the target latency is in ms, so the expected value is 1000.
+      // In LL-DASH MPD, the target latency is in ms, so the expected value is
+      // 1000.
       "    <Latency target=\"1000\"/>"
       "  </ServiceDescription>"
       // ContentType and Representation elements are populated after

--- a/packager/mpd/base/period_unittest.cc
+++ b/packager/mpd/base/period_unittest.cc
@@ -186,7 +186,7 @@ TEST_F(PeriodTest, LowLatencyDashMpdGetXml) {
       "}\n"
       "container_type: 1\n";
   mpd_options_.mpd_type = MpdType::kDynamic;
-  mpd_options_.mpd_params.is_low_latency_dash = true;
+  mpd_options_.mpd_params.low_latency_dash_mode = true;
   mpd_options_.mpd_params.target_latency_seconds = 1;
 
   EXPECT_CALL(testable_period_, NewAdaptationSet(_, _, _))

--- a/packager/mpd/base/representation.cc
+++ b/packager/mpd/base/representation.cc
@@ -274,7 +274,8 @@ base::Optional<xml::XmlNode> Representation::GetXml() {
 
   if (HasLiveOnlyFields(media_info_) &&
       !representation.AddLiveOnlyInfo(media_info_, segment_infos_,
-                                      start_number_)) {
+                                      start_number_, 
+                                      mpd_options_.mpd_params.target_segment_duration)) {
     LOG(ERROR) << "Failed to add Live info.";
     return base::nullopt;
   }

--- a/packager/mpd/base/representation.cc
+++ b/packager/mpd/base/representation.cc
@@ -308,6 +308,11 @@ void Representation::SetPresentationTimeOffset(
 void Representation::SetAvailabilityTimeOffset() {
   // Adjust the frame duration to units of seconds to match target segment duration.
   const float frame_duration_sec = (float)frame_duration_ / (float)media_info_.reference_time_scale();
+  // availabilityTimeOffset = segment duration - chunk duration.
+  // Here, the frame duration is equivalent to the sample duration, 
+  // see Representation::SetSampleDuration(uint32_t frame_duration). 
+  // By definition, each chunk will contain only one sample; 
+  // thus, chunk_duration = sample_duration = frame_duration.
   const float ato = mpd_options_.mpd_params.target_segment_duration - frame_duration_sec;
   if (ato <= 0)
     return;

--- a/packager/mpd/base/representation.cc
+++ b/packager/mpd/base/representation.cc
@@ -297,6 +297,16 @@ void Representation::SetPresentationTimeOffset(
   media_info_.set_presentation_time_offset(pto);
 }
 
+void Representation::SetAvailabilityTimeOffset() {
+  // Adjust the frame duration to units of seconds to match target segment duration.
+  float frame_duration_sec = (float)frame_duration_ / (float)media_info_.reference_time_scale();
+  float ato = mpd_options_.mpd_params.target_segment_duration - frame_duration_sec;
+  if (ato <= 0)
+    return;
+  // TODO(Caitlin): Restrict availability time offset to the desired precision. 
+  media_info_.set_availability_time_offset(ato);
+}
+
 bool Representation::GetStartAndEndTimestamps(
     double* start_timestamp_seconds,
     double* end_timestamp_seconds) const {

--- a/packager/mpd/base/representation.cc
+++ b/packager/mpd/base/representation.cc
@@ -9,7 +9,6 @@
 #include <gflags/gflags.h>
 
 #include <algorithm>
-#include <math.h> 
 
 #include "packager/base/logging.h"
 #include "packager/base/strings/stringprintf.h"
@@ -283,7 +282,7 @@ base::Optional<xml::XmlNode> Representation::GetXml() {
   if (HasLiveOnlyFields(media_info_) &&
       !representation.AddLiveOnlyInfo(media_info_, segment_infos_,
                                       start_number_, 
-                                      mpd_options_.mpd_params.target_segment_duration)) {
+                                      mpd_options_.mpd_params.is_low_latency_dash)) {
     LOG(ERROR) << "Failed to add Live info.";
     return base::nullopt;
   }
@@ -309,11 +308,9 @@ void Representation::SetPresentationTimeOffset(
 void Representation::SetAvailabilityTimeOffset() {
   // Adjust the frame duration to units of seconds to match target segment duration.
   const float frame_duration_sec = (float)frame_duration_ / (float)media_info_.reference_time_scale();
-  float tmp = mpd_options_.mpd_params.target_segment_duration - frame_duration_sec;
-  float ato = round(tmp * 1000) / 1000;
+  const float ato = mpd_options_.mpd_params.target_segment_duration - frame_duration_sec;
   if (ato <= 0)
     return;
-  // TODO(Caitlin): Restrict availability time offset to the desired precision. 
   media_info_.set_availability_time_offset(ato);
 }
 

--- a/packager/mpd/base/representation.cc
+++ b/packager/mpd/base/representation.cc
@@ -283,7 +283,7 @@ base::Optional<xml::XmlNode> Representation::GetXml() {
   if (HasLiveOnlyFields(media_info_) &&
       !representation.AddLiveOnlyInfo(
           media_info_, segment_infos_, start_number_,
-          mpd_options_.mpd_params.is_low_latency_dash)) {
+          mpd_options_.mpd_params.low_latency_dash_mode)) {
     LOG(ERROR) << "Failed to add Live info.";
     return base::nullopt;
   }

--- a/packager/mpd/base/representation.cc
+++ b/packager/mpd/base/representation.cc
@@ -9,6 +9,7 @@
 #include <gflags/gflags.h>
 
 #include <algorithm>
+#include <math.h> 
 
 #include "packager/base/logging.h"
 #include "packager/base/strings/stringprintf.h"
@@ -300,8 +301,9 @@ void Representation::SetPresentationTimeOffset(
 
 void Representation::SetAvailabilityTimeOffset() {
   // Adjust the frame duration to units of seconds to match target segment duration.
-  float frame_duration_sec = (float)frame_duration_ / (float)media_info_.reference_time_scale();
-  float ato = mpd_options_.mpd_params.target_segment_duration - frame_duration_sec;
+  const float frame_duration_sec = (float)frame_duration_ / (float)media_info_.reference_time_scale();
+  float tmp = mpd_options_.mpd_params.target_segment_duration - frame_duration_sec;
+  float ato = round(tmp * 1000) / 1000;
   if (ato <= 0)
     return;
   // TODO(Caitlin): Restrict availability time offset to the desired precision. 

--- a/packager/mpd/base/representation.cc
+++ b/packager/mpd/base/representation.cc
@@ -309,14 +309,14 @@ void Representation::SetPresentationTimeOffset(
 void Representation::SetAvailabilityTimeOffset() {
   // Adjust the frame duration to units of seconds to match target segment
   // duration.
-  const float frame_duration_sec =
-      (float)frame_duration_ / (float)media_info_.reference_time_scale();
+  const double frame_duration_sec =
+      (double)frame_duration_ / (double)media_info_.reference_time_scale();
   // availabilityTimeOffset = segment duration - chunk duration.
   // Here, the frame duration is equivalent to the sample duration,
   // see Representation::SetSampleDuration(uint32_t frame_duration).
   // By definition, each chunk will contain only one sample;
   // thus, chunk_duration = sample_duration = frame_duration.
-  const float ato =
+  const double ato =
       mpd_options_.mpd_params.target_segment_duration - frame_duration_sec;
   if (ato <= 0)
     return;

--- a/packager/mpd/base/representation.cc
+++ b/packager/mpd/base/representation.cc
@@ -209,7 +209,8 @@ void Representation::SetSampleDuration(int32_t frame_duration) {
 }
 
 void Representation::SetSegmentDuration() {
-  int64_t sd = mpd_options_.mpd_params.target_segment_duration * media_info_.reference_time_scale();
+  int64_t sd = mpd_options_.mpd_params.target_segment_duration *
+               media_info_.reference_time_scale();
   if (sd <= 0)
     return;
   media_info_.set_segment_duration(sd);
@@ -280,9 +281,9 @@ base::Optional<xml::XmlNode> Representation::GetXml() {
   }
 
   if (HasLiveOnlyFields(media_info_) &&
-      !representation.AddLiveOnlyInfo(media_info_, segment_infos_,
-                                      start_number_, 
-                                      mpd_options_.mpd_params.is_low_latency_dash)) {
+      !representation.AddLiveOnlyInfo(
+          media_info_, segment_infos_, start_number_,
+          mpd_options_.mpd_params.is_low_latency_dash)) {
     LOG(ERROR) << "Failed to add Live info.";
     return base::nullopt;
   }
@@ -306,14 +307,17 @@ void Representation::SetPresentationTimeOffset(
 }
 
 void Representation::SetAvailabilityTimeOffset() {
-  // Adjust the frame duration to units of seconds to match target segment duration.
-  const float frame_duration_sec = (float)frame_duration_ / (float)media_info_.reference_time_scale();
+  // Adjust the frame duration to units of seconds to match target segment
+  // duration.
+  const float frame_duration_sec =
+      (float)frame_duration_ / (float)media_info_.reference_time_scale();
   // availabilityTimeOffset = segment duration - chunk duration.
-  // Here, the frame duration is equivalent to the sample duration, 
-  // see Representation::SetSampleDuration(uint32_t frame_duration). 
-  // By definition, each chunk will contain only one sample; 
+  // Here, the frame duration is equivalent to the sample duration,
+  // see Representation::SetSampleDuration(uint32_t frame_duration).
+  // By definition, each chunk will contain only one sample;
   // thus, chunk_duration = sample_duration = frame_duration.
-  const float ato = mpd_options_.mpd_params.target_segment_duration - frame_duration_sec;
+  const float ato =
+      mpd_options_.mpd_params.target_segment_duration - frame_duration_sec;
   if (ato <= 0)
     return;
   media_info_.set_availability_time_offset(ato);

--- a/packager/mpd/base/representation.cc
+++ b/packager/mpd/base/representation.cc
@@ -209,6 +209,13 @@ void Representation::SetSampleDuration(int32_t frame_duration) {
   }
 }
 
+void Representation::SetSegmentDuration(double segment_duration) {
+  int64_t sd = segment_duration * media_info_.reference_time_scale();
+  if (sd <= 0)
+    return;
+  media_info_.set_segment_duration(sd);
+}
+
 const MediaInfo& Representation::GetMediaInfo() const {
   return media_info_;
 }

--- a/packager/mpd/base/representation.cc
+++ b/packager/mpd/base/representation.cc
@@ -208,8 +208,8 @@ void Representation::SetSampleDuration(int32_t frame_duration) {
   }
 }
 
-void Representation::SetSegmentDuration(double segment_duration) {
-  int64_t sd = segment_duration * media_info_.reference_time_scale();
+void Representation::SetSegmentDuration() {
+  int64_t sd = mpd_options_.mpd_params.target_segment_duration * media_info_.reference_time_scale();
   if (sd <= 0)
     return;
   media_info_.set_segment_duration(sd);

--- a/packager/mpd/base/representation.h
+++ b/packager/mpd/base/representation.h
@@ -127,9 +127,13 @@ class Representation {
   /// Set @presentationTimeOffset in SegmentBase / SegmentTemplate.
   void SetPresentationTimeOffset(double presentation_time_offset);
 
-  // TODO(Caitlin): add description
-  /// Set @availabilityTimeOffset when streaming Low Latency DASH.
+  /// Set @availabilityTimeOffset in SegmentTemplate.
+  /// This is necessary for Low Latency DASH streaming.
   void SetAvailabilityTimeOffset();
+
+  /// Set @duration in SegmentTemplate.
+  /// This is necessary for Low Latency DASH streaming.
+  void SetSegmentDuration(double segment_duration);
 
   /// Gets the start and end timestamps in seconds.
   /// @param start_timestamp_seconds contains the returned start timestamp in

--- a/packager/mpd/base/representation.h
+++ b/packager/mpd/base/representation.h
@@ -127,6 +127,10 @@ class Representation {
   /// Set @presentationTimeOffset in SegmentBase / SegmentTemplate.
   void SetPresentationTimeOffset(double presentation_time_offset);
 
+  // TODO(Caitlin): add description
+  /// Set @availabilityTimeOffset when streaming Low Latency DASH.
+  void SetAvailabilityTimeOffset();
+
   /// Gets the start and end timestamps in seconds.
   /// @param start_timestamp_seconds contains the returned start timestamp in
   ///        seconds on success. It can be nullptr, which means that start

--- a/packager/mpd/base/representation.h
+++ b/packager/mpd/base/representation.h
@@ -133,7 +133,7 @@ class Representation {
 
   /// Set @duration in SegmentTemplate.
   /// This is necessary for Low Latency DASH streaming.
-  void SetSegmentDuration(double segment_duration);
+  void SetSegmentDuration();
 
   /// Gets the start and end timestamps in seconds.
   /// @param start_timestamp_seconds contains the returned start timestamp in

--- a/packager/mpd/base/simple_mpd_notifier.cc
+++ b/packager/mpd/base/simple_mpd_notifier.cc
@@ -101,7 +101,7 @@ bool SimpleMpdNotifier::NotifySegmentDuration(uint32_t container_id) {
     LOG(ERROR) << "Unexpected container_id: " << container_id;
     return false;
   }
-  it->second->SetSegmentDuration(target_segment_duration());
+  it->second->SetSegmentDuration();
   return true;
 }
 

--- a/packager/mpd/base/simple_mpd_notifier.cc
+++ b/packager/mpd/base/simple_mpd_notifier.cc
@@ -71,7 +71,7 @@ bool SimpleMpdNotifier::NotifyNewContainer(const MediaInfo& media_info,
   return true;
 }
 
-bool SimpleMpdNotifier::NotifyChunkDuration(uint32_t container_id) {
+bool SimpleMpdNotifier::NotifyAvailabilityTimeOffset(uint32_t container_id) {
   base::AutoLock auto_lock(lock_);
   auto it = representation_map_.find(container_id);
   if (it == representation_map_.end()) {

--- a/packager/mpd/base/simple_mpd_notifier.cc
+++ b/packager/mpd/base/simple_mpd_notifier.cc
@@ -71,6 +71,17 @@ bool SimpleMpdNotifier::NotifyNewContainer(const MediaInfo& media_info,
   return true;
 }
 
+bool SimpleMpdNotifier::NotifyChunkDuration(uint32_t container_id) {
+  base::AutoLock auto_lock(lock_);
+  auto it = representation_map_.find(container_id);
+  if (it == representation_map_.end()) {
+    LOG(ERROR) << "Unexpected container_id: " << container_id;
+    return false;
+  }
+  it->second->SetAvailabilityTimeOffset();
+  return true;
+}
+
 bool SimpleMpdNotifier::NotifySampleDuration(uint32_t container_id,
                                              int32_t sample_duration) {
   base::AutoLock auto_lock(lock_);

--- a/packager/mpd/base/simple_mpd_notifier.cc
+++ b/packager/mpd/base/simple_mpd_notifier.cc
@@ -94,6 +94,17 @@ bool SimpleMpdNotifier::NotifySampleDuration(uint32_t container_id,
   return true;
 }
 
+bool SimpleMpdNotifier::NotifySegmentDuration(uint32_t container_id) {
+  base::AutoLock auto_lock(lock_);
+  auto it = representation_map_.find(container_id);
+  if (it == representation_map_.end()) {
+    LOG(ERROR) << "Unexpected container_id: " << container_id;
+    return false;
+  }
+  it->second->SetSegmentDuration(target_segment_duration());
+  return true;
+}
+
 bool SimpleMpdNotifier::NotifyNewSegment(uint32_t container_id,
                                          int64_t start_time,
                                          int64_t duration,

--- a/packager/mpd/base/simple_mpd_notifier.h
+++ b/packager/mpd/base/simple_mpd_notifier.h
@@ -39,6 +39,7 @@ class SimpleMpdNotifier : public MpdNotifier {
   bool NotifyChunkDuration(uint32_t container_id) override;
   bool NotifySampleDuration(uint32_t container_id,
                             int32_t sample_duration) override;
+  bool NotifySegmentDuration(uint32_t container_id) override;
   bool NotifyNewSegment(uint32_t container_id,
                         int64_t start_time,
                         int64_t duration,

--- a/packager/mpd/base/simple_mpd_notifier.h
+++ b/packager/mpd/base/simple_mpd_notifier.h
@@ -36,6 +36,7 @@ class SimpleMpdNotifier : public MpdNotifier {
   /// @{
   bool Init() override;
   bool NotifyNewContainer(const MediaInfo& media_info, uint32_t* id) override;
+  bool NotifyChunkDuration(uint32_t container_id) override;
   bool NotifySampleDuration(uint32_t container_id,
                             int32_t sample_duration) override;
   bool NotifyNewSegment(uint32_t container_id,

--- a/packager/mpd/base/simple_mpd_notifier.h
+++ b/packager/mpd/base/simple_mpd_notifier.h
@@ -36,7 +36,7 @@ class SimpleMpdNotifier : public MpdNotifier {
   /// @{
   bool Init() override;
   bool NotifyNewContainer(const MediaInfo& media_info, uint32_t* id) override;
-  bool NotifyChunkDuration(uint32_t container_id) override;
+  bool NotifyAvailabilityTimeOffset(uint32_t container_id) override;
   bool NotifySampleDuration(uint32_t container_id,
                             int32_t sample_duration) override;
   bool NotifySegmentDuration(uint32_t container_id) override;

--- a/packager/mpd/base/simple_mpd_notifier_unittest.cc
+++ b/packager/mpd/base/simple_mpd_notifier_unittest.cc
@@ -177,6 +177,32 @@ TEST_F(SimpleMpdNotifierTest, NotifySegmentDuration) {
       notifier.NotifySegmentDuration(kRepresentationId));
 }
 
+TEST_F(SimpleMpdNotifierTest, NotifyAvailabilityTimeOffset) {
+  SimpleMpdNotifier notifier(empty_mpd_option_);
+
+  const uint32_t kRepresentationId = 10u;  
+  std::unique_ptr<MockMpdBuilder> mock_mpd_builder(new MockMpdBuilder());
+  std::unique_ptr<MockRepresentation> mock_representation(
+      new MockRepresentation(kRepresentationId));
+
+  EXPECT_CALL(*mock_mpd_builder, GetOrCreatePeriod(_))
+      .WillOnce(Return(default_mock_period_.get()));
+  EXPECT_CALL(*default_mock_period_, GetOrCreateAdaptationSet(_, _))
+      .WillOnce(Return(default_mock_adaptation_set_.get()));
+  EXPECT_CALL(*default_mock_adaptation_set_, AddRepresentation(_))
+      .WillOnce(Return(mock_representation.get()));
+
+  uint32_t container_id;
+  SetMpdBuilder(&notifier, std::move(mock_mpd_builder));
+  EXPECT_TRUE(notifier.NotifyNewContainer(valid_media_info1_, &container_id));
+  EXPECT_EQ(kRepresentationId, container_id);
+
+  mock_representation->SetAvailabilityTimeOffset();
+
+  EXPECT_TRUE(
+      notifier.NotifyAvailabilityTimeOffset(kRepresentationId));
+}
+
 // This test is mainly for tsan. Using both the notifier and the MpdBuilder.
 // Although locks in MpdBuilder have been removed,
 // https://github.com/google/shaka-packager/issues/45

--- a/packager/mpd/base/simple_mpd_notifier_unittest.cc
+++ b/packager/mpd/base/simple_mpd_notifier_unittest.cc
@@ -154,7 +154,7 @@ TEST_F(SimpleMpdNotifierTest, NotifySampleDuration) {
 TEST_F(SimpleMpdNotifierTest, NotifySegmentDuration) {
   SimpleMpdNotifier notifier(empty_mpd_option_);
 
-  const uint32_t kRepresentationId = 9u;  
+  const uint32_t kRepresentationId = 9u;
   std::unique_ptr<MockMpdBuilder> mock_mpd_builder(new MockMpdBuilder());
   std::unique_ptr<MockRepresentation> mock_representation(
       new MockRepresentation(kRepresentationId));
@@ -173,14 +173,13 @@ TEST_F(SimpleMpdNotifierTest, NotifySegmentDuration) {
 
   mock_representation->SetSegmentDuration();
 
-  EXPECT_TRUE(
-      notifier.NotifySegmentDuration(kRepresentationId));
+  EXPECT_TRUE(notifier.NotifySegmentDuration(kRepresentationId));
 }
 
 TEST_F(SimpleMpdNotifierTest, NotifyAvailabilityTimeOffset) {
   SimpleMpdNotifier notifier(empty_mpd_option_);
 
-  const uint32_t kRepresentationId = 10u;  
+  const uint32_t kRepresentationId = 10u;
   std::unique_ptr<MockMpdBuilder> mock_mpd_builder(new MockMpdBuilder());
   std::unique_ptr<MockRepresentation> mock_representation(
       new MockRepresentation(kRepresentationId));
@@ -199,8 +198,7 @@ TEST_F(SimpleMpdNotifierTest, NotifyAvailabilityTimeOffset) {
 
   mock_representation->SetAvailabilityTimeOffset();
 
-  EXPECT_TRUE(
-      notifier.NotifyAvailabilityTimeOffset(kRepresentationId));
+  EXPECT_TRUE(notifier.NotifyAvailabilityTimeOffset(kRepresentationId));
 }
 
 // This test is mainly for tsan. Using both the notifier and the MpdBuilder.

--- a/packager/mpd/base/xml/xml_node.cc
+++ b/packager/mpd/base/xml/xml_node.cc
@@ -468,11 +468,9 @@ bool RepresentationXmlNode::AddLiveOnlyInfo(
         "timescale", media_info.reference_time_scale()));
   }
 
-  // TODO(Caitlin): Improve logic to detect whether LL DASH or not. 
-  // if LL DASH
-  if (media_info.has_availability_time_offset()) {
-    const uint64_t duration = target_segment_duration * media_info.reference_time_scale();
-    RCHECK(segment_template.SetIntegerAttribute("duration", duration));
+  if (media_info.has_segment_duration()) {
+    RCHECK(segment_template.SetIntegerAttribute(
+        "duration", media_info.segment_duration()));
   }
 
   if (media_info.has_presentation_time_offset()) {

--- a/packager/mpd/base/xml/xml_node.cc
+++ b/packager/mpd/base/xml/xml_node.cc
@@ -469,8 +469,8 @@ bool RepresentationXmlNode::AddLiveOnlyInfo(
   }
 
   if (media_info.has_segment_duration()) {
-    RCHECK(segment_template.SetIntegerAttribute(
-        "duration", media_info.segment_duration()));
+    RCHECK(segment_template.SetIntegerAttribute("duration",
+                                                media_info.segment_duration()));
   }
 
   if (media_info.has_presentation_time_offset()) {
@@ -481,7 +481,8 @@ bool RepresentationXmlNode::AddLiveOnlyInfo(
   if (media_info.has_availability_time_offset()) {
     // Set the availabilityTimeOffset to the precision of 3 decimal places.
     RCHECK(segment_template.SetFloatingPointAttribute(
-        "availabilityTimeOffset", round(media_info.availability_time_offset()*1000)/1000));
+        "availabilityTimeOffset",
+        round(media_info.availability_time_offset() * 1000) / 1000));
   }
 
   if (media_info.has_init_segment_url()) {
@@ -511,7 +512,7 @@ bool RepresentationXmlNode::AddLiveOnlyInfo(
             std::to_string(last_segment_number)));
       }
     } else {
-      if (!is_low_latency_dash){
+      if (!is_low_latency_dash) {
         XmlNode segment_timeline("SegmentTimeline");
         RCHECK(PopulateSegmentTimeline(segment_infos, &segment_timeline));
         RCHECK(segment_template.AddChild(std::move(segment_timeline)));

--- a/packager/mpd/base/xml/xml_node.cc
+++ b/packager/mpd/base/xml/xml_node.cc
@@ -472,6 +472,11 @@ bool RepresentationXmlNode::AddLiveOnlyInfo(
         "presentationTimeOffset", media_info.presentation_time_offset()));
   }
 
+  if (media_info.has_availability_time_offset()) {
+    RCHECK(segment_template.SetFloatingPointAttribute(
+        "availabilityTimeOffset", media_info.availability_time_offset()));
+  }
+
   if (media_info.has_init_segment_url()) {
     RCHECK(segment_template.SetStringAttribute("initialization",
                                                media_info.init_segment_url()));

--- a/packager/mpd/base/xml/xml_node.cc
+++ b/packager/mpd/base/xml/xml_node.cc
@@ -461,7 +461,7 @@ bool RepresentationXmlNode::AddLiveOnlyInfo(
     const MediaInfo& media_info,
     const std::list<SegmentInfo>& segment_infos,
     uint32_t start_number,
-    double target_segment_duration) {
+    bool is_low_latency_dash) {
   XmlNode segment_template("SegmentTemplate");
   if (media_info.has_reference_time_scale()) {
     RCHECK(segment_template.SetIntegerAttribute(
@@ -479,7 +479,7 @@ bool RepresentationXmlNode::AddLiveOnlyInfo(
   }
 
   if (media_info.has_availability_time_offset()) {
-    // TODO(Caitlin): round availability time offset in only 1 location
+    // Set the availabilityTimeOffset to the precision of 3 decimal places.
     RCHECK(segment_template.SetFloatingPointAttribute(
         "availabilityTimeOffset", round(media_info.availability_time_offset()*1000)/1000));
   }
@@ -511,9 +511,7 @@ bool RepresentationXmlNode::AddLiveOnlyInfo(
             std::to_string(last_segment_number)));
       }
     } else {
-      // TODO(Caitlin): Improve logic to detect whether LL DASH or not. 
-      // if LL DASH
-      if (!media_info.has_availability_time_offset()){
+      if (!is_low_latency_dash){
         XmlNode segment_timeline("SegmentTimeline");
         RCHECK(PopulateSegmentTimeline(segment_infos, &segment_timeline));
         RCHECK(segment_template.AddChild(std::move(segment_timeline)));

--- a/packager/mpd/base/xml/xml_node.cc
+++ b/packager/mpd/base/xml/xml_node.cc
@@ -481,7 +481,7 @@ bool RepresentationXmlNode::AddLiveOnlyInfo(
   if (media_info.has_availability_time_offset()) {
     RCHECK(segment_template.SetFloatingPointAttribute(
         "availabilityTimeOffset",
-        media_info.availability_time_offset());
+        media_info.availability_time_offset()));
   }
 
   if (media_info.has_init_segment_url()) {

--- a/packager/mpd/base/xml/xml_node.cc
+++ b/packager/mpd/base/xml/xml_node.cc
@@ -461,7 +461,7 @@ bool RepresentationXmlNode::AddLiveOnlyInfo(
     const MediaInfo& media_info,
     const std::list<SegmentInfo>& segment_infos,
     uint32_t start_number,
-    bool is_low_latency_dash) {
+    bool low_latency_dash_mode) {
   XmlNode segment_template("SegmentTemplate");
   if (media_info.has_reference_time_scale()) {
     RCHECK(segment_template.SetIntegerAttribute(
@@ -510,7 +510,7 @@ bool RepresentationXmlNode::AddLiveOnlyInfo(
             std::to_string(last_segment_number)));
       }
     } else {
-      if (!is_low_latency_dash) {
+      if (!low_latency_dash_mode) {
         XmlNode segment_timeline("SegmentTimeline");
         RCHECK(PopulateSegmentTimeline(segment_infos, &segment_timeline));
         RCHECK(segment_template.AddChild(std::move(segment_timeline)));

--- a/packager/mpd/base/xml/xml_node.cc
+++ b/packager/mpd/base/xml/xml_node.cc
@@ -479,10 +479,9 @@ bool RepresentationXmlNode::AddLiveOnlyInfo(
   }
 
   if (media_info.has_availability_time_offset()) {
-    // Set the availabilityTimeOffset to the precision of 3 decimal places.
     RCHECK(segment_template.SetFloatingPointAttribute(
         "availabilityTimeOffset",
-        round(media_info.availability_time_offset() * 1000) / 1000));
+        media_info.availability_time_offset());
   }
 
   if (media_info.has_init_segment_url()) {

--- a/packager/mpd/base/xml/xml_node.cc
+++ b/packager/mpd/base/xml/xml_node.cc
@@ -480,8 +480,7 @@ bool RepresentationXmlNode::AddLiveOnlyInfo(
 
   if (media_info.has_availability_time_offset()) {
     RCHECK(segment_template.SetFloatingPointAttribute(
-        "availabilityTimeOffset",
-        media_info.availability_time_offset()));
+        "availabilityTimeOffset", media_info.availability_time_offset()));
   }
 
   if (media_info.has_init_segment_url()) {

--- a/packager/mpd/base/xml/xml_node.cc
+++ b/packager/mpd/base/xml/xml_node.cc
@@ -481,8 +481,9 @@ bool RepresentationXmlNode::AddLiveOnlyInfo(
   }
 
   if (media_info.has_availability_time_offset()) {
+    // TODO(Caitlin): round availability time offset in only 1 location
     RCHECK(segment_template.SetFloatingPointAttribute(
-        "availabilityTimeOffset", media_info.availability_time_offset()));
+        "availabilityTimeOffset", round(media_info.availability_time_offset()*1000)/1000));
   }
 
   if (media_info.has_init_segment_url()) {

--- a/packager/mpd/base/xml/xml_node.h
+++ b/packager/mpd/base/xml/xml_node.h
@@ -220,7 +220,7 @@ class RepresentationXmlNode : public RepresentationBaseXmlNode {
   bool AddLiveOnlyInfo(const MediaInfo& media_info,
                        const std::list<SegmentInfo>& segment_infos,
                        uint32_t start_number,
-                       bool is_low_latency_dash) WARN_UNUSED_RESULT;
+                       bool low_latency_dash_mode) WARN_UNUSED_RESULT;
 
  private:
   // Add AudioChannelConfiguration element. Note that it is a required element

--- a/packager/mpd/base/xml/xml_node.h
+++ b/packager/mpd/base/xml/xml_node.h
@@ -220,7 +220,7 @@ class RepresentationXmlNode : public RepresentationBaseXmlNode {
   bool AddLiveOnlyInfo(const MediaInfo& media_info,
                        const std::list<SegmentInfo>& segment_infos,
                        uint32_t start_number,
-                       double target_segment_duration = 0) WARN_UNUSED_RESULT;
+                       bool is_low_latency_dash) WARN_UNUSED_RESULT;
 
  private:
   // Add AudioChannelConfiguration element. Note that it is a required element

--- a/packager/mpd/base/xml/xml_node.h
+++ b/packager/mpd/base/xml/xml_node.h
@@ -219,7 +219,8 @@ class RepresentationXmlNode : public RepresentationBaseXmlNode {
   ///        SegmentInfos are sorted by its start time.
   bool AddLiveOnlyInfo(const MediaInfo& media_info,
                        const std::list<SegmentInfo>& segment_infos,
-                       uint32_t start_number) WARN_UNUSED_RESULT;
+                       uint32_t start_number,
+                       double target_segment_duration = 0) WARN_UNUSED_RESULT;
 
  private:
   // Add AudioChannelConfiguration element. Note that it is a required element

--- a/packager/mpd/base/xml/xml_node_unittest.cc
+++ b/packager/mpd/base/xml/xml_node_unittest.cc
@@ -751,7 +751,7 @@ TEST_F(LowLatencySegmentTest, LowLatencySegmentTemplate) {
       representation,
       XmlNodeEqual("<Representation>"
                    "  <SegmentTemplate timescale=\"90000\" duration=\"450000\" "
-                   "                   availabilityTimeOffset=\"4.975\" "
+                   "                   availabilityTimeOffset=\"4.9750987314\" "
                    "                   initialization=\"init.m4s\" "
                    "                   media=\"$Number$.m4s\" "
                    "                   startNumber=\"1\"/>"

--- a/packager/mpd/base/xml/xml_node_unittest.cc
+++ b/packager/mpd/base/xml/xml_node_unittest.cc
@@ -741,21 +741,21 @@ TEST_F(LowLatencySegmentTest, LowLatencySegmentTemplate) {
   const uint64_t kRepeat = 0;
   const bool kIsLowLatency = true;
 
-    std::list<SegmentInfo> segment_infos = {
+  std::list<SegmentInfo> segment_infos = {
       {kStartNumber, kDuration, kRepeat},
   };
   RepresentationXmlNode representation;
   ASSERT_TRUE(representation.AddLiveOnlyInfo(media_info_, segment_infos,
                                              kStartNumber, kIsLowLatency));
-  EXPECT_THAT(representation,
-              XmlNodeEqual(
-                  "<Representation>"
-                  "  <SegmentTemplate timescale=\"90000\" duration=\"450000\" "
-                  "                   availabilityTimeOffset=\"4.9\" "
-                  "                   initialization=\"init.m4s\" "
-                  "                   media=\"$Number$.m4s\" "
-                  "                   startNumber=\"1\"/>"
-                  "</Representation>"));
+  EXPECT_THAT(
+      representation,
+      XmlNodeEqual("<Representation>"
+                   "  <SegmentTemplate timescale=\"90000\" duration=\"450000\" "
+                   "                   availabilityTimeOffset=\"4.9\" "
+                   "                   initialization=\"init.m4s\" "
+                   "                   media=\"$Number$.m4s\" "
+                   "                   startNumber=\"1\"/>"
+                   "</Representation>"));
 }
 
 }  // namespace xml

--- a/packager/mpd/base/xml/xml_node_unittest.cc
+++ b/packager/mpd/base/xml/xml_node_unittest.cc
@@ -728,7 +728,7 @@ class LowLatencySegmentTest : public ::testing::Test {
     media_info_.set_init_segment_url("init.m4s");
     media_info_.set_segment_template_url("$Number$.m4s");
     media_info_.set_reference_time_scale(90000);
-    media_info_.set_availability_time_offset(4.900);
+    media_info_.set_availability_time_offset(4.900f);
     media_info_.set_segment_duration(450000);
   }
 

--- a/packager/mpd/base/xml/xml_node_unittest.cc
+++ b/packager/mpd/base/xml/xml_node_unittest.cc
@@ -374,8 +374,8 @@ TEST_F(LiveSegmentTimelineTest, OneSegmentInfo) {
       {kStartTime, kDuration, kRepeat},
   };
   RepresentationXmlNode representation;
-  ASSERT_TRUE(
-      representation.AddLiveOnlyInfo(media_info_, segment_infos, kStartNumber, kIsLowLatency));
+  ASSERT_TRUE(representation.AddLiveOnlyInfo(media_info_, segment_infos,
+                                             kStartNumber, kIsLowLatency));
 
   EXPECT_THAT(
       representation,
@@ -396,8 +396,8 @@ TEST_F(LiveSegmentTimelineTest, OneSegmentInfoNonZeroStartTime) {
       {kNonZeroStartTime, kDuration, kRepeat},
   };
   RepresentationXmlNode representation;
-  ASSERT_TRUE(
-      representation.AddLiveOnlyInfo(media_info_, segment_infos, kStartNumber, kIsLowLatency));
+  ASSERT_TRUE(representation.AddLiveOnlyInfo(media_info_, segment_infos,
+                                             kStartNumber, kIsLowLatency));
 
   EXPECT_THAT(representation,
               XmlNodeEqual(
@@ -421,8 +421,8 @@ TEST_F(LiveSegmentTimelineTest, OneSegmentInfoMatchingStartTimeAndNumber) {
       {kNonZeroStartTime, kDuration, kRepeat},
   };
   RepresentationXmlNode representation;
-  ASSERT_TRUE(
-      representation.AddLiveOnlyInfo(media_info_, segment_infos, kStartNumber, kIsLowLatency));
+  ASSERT_TRUE(representation.AddLiveOnlyInfo(media_info_, segment_infos,
+                                             kStartNumber, kIsLowLatency));
 
   EXPECT_THAT(
       representation,
@@ -449,8 +449,8 @@ TEST_F(LiveSegmentTimelineTest, AllSegmentsSameDurationExpectLastOne) {
       {kStartTime2, kDuration2, kRepeat2},
   };
   RepresentationXmlNode representation;
-  ASSERT_TRUE(
-      representation.AddLiveOnlyInfo(media_info_, segment_infos, kStartNumber, kIsLowLatency));
+  ASSERT_TRUE(representation.AddLiveOnlyInfo(media_info_, segment_infos,
+                                             kStartNumber, kIsLowLatency));
 
   EXPECT_THAT(
       representation,
@@ -477,8 +477,8 @@ TEST_F(LiveSegmentTimelineTest, SecondSegmentInfoNonZeroRepeat) {
       {kStartTime2, kDuration2, kRepeat2},
   };
   RepresentationXmlNode representation;
-  ASSERT_TRUE(
-      representation.AddLiveOnlyInfo(media_info_, segment_infos, kStartNumber, kIsLowLatency));
+  ASSERT_TRUE(representation.AddLiveOnlyInfo(media_info_, segment_infos,
+                                             kStartNumber, kIsLowLatency));
 
   EXPECT_THAT(representation,
               XmlNodeEqual(
@@ -510,8 +510,8 @@ TEST_F(LiveSegmentTimelineTest, TwoSegmentInfoWithGap) {
       {kStartTime2, kDuration2, kRepeat2},
   };
   RepresentationXmlNode representation;
-  ASSERT_TRUE(
-      representation.AddLiveOnlyInfo(media_info_, segment_infos, kStartNumber, kIsLowLatency));
+  ASSERT_TRUE(representation.AddLiveOnlyInfo(media_info_, segment_infos,
+                                             kStartNumber, kIsLowLatency));
 
   EXPECT_THAT(representation,
               XmlNodeEqual(
@@ -538,8 +538,8 @@ TEST_F(LiveSegmentTimelineTest, LastSegmentNumberSupplementalProperty) {
   RepresentationXmlNode representation;
   FLAGS_dash_add_last_segment_number_when_needed = true;
 
-  ASSERT_TRUE(
-      representation.AddLiveOnlyInfo(media_info_, segment_infos, kStartNumber, kIsLowLatency));
+  ASSERT_TRUE(representation.AddLiveOnlyInfo(media_info_, segment_infos,
+                                             kStartNumber, kIsLowLatency));
 
   EXPECT_THAT(
       representation,

--- a/packager/mpd/base/xml/xml_node_unittest.cc
+++ b/packager/mpd/base/xml/xml_node_unittest.cc
@@ -728,7 +728,7 @@ class LowLatencySegmentTest : public ::testing::Test {
     media_info_.set_init_segment_url("init.m4s");
     media_info_.set_segment_template_url("$Number$.m4s");
     media_info_.set_reference_time_scale(90000);
-    media_info_.set_availability_time_offset(4.900f);
+    media_info_.set_availability_time_offset(4.9750987314f);
     media_info_.set_segment_duration(450000);
   }
 
@@ -751,7 +751,7 @@ TEST_F(LowLatencySegmentTest, LowLatencySegmentTemplate) {
       representation,
       XmlNodeEqual("<Representation>"
                    "  <SegmentTemplate timescale=\"90000\" duration=\"450000\" "
-                   "                   availabilityTimeOffset=\"4.9\" "
+                   "                   availabilityTimeOffset=\"4.975\" "
                    "                   initialization=\"init.m4s\" "
                    "                   media=\"$Number$.m4s\" "
                    "                   startNumber=\"1\"/>"

--- a/packager/mpd/base/xml/xml_node_unittest.cc
+++ b/packager/mpd/base/xml/xml_node_unittest.cc
@@ -728,7 +728,7 @@ class LowLatencySegmentTest : public ::testing::Test {
     media_info_.set_init_segment_url("init.m4s");
     media_info_.set_segment_template_url("$Number$.m4s");
     media_info_.set_reference_time_scale(90000);
-    media_info_.set_availability_time_offset(4.9750987314f);
+    media_info_.set_availability_time_offset(4.9750987314);
     media_info_.set_segment_duration(450000);
   }
 

--- a/packager/mpd/base/xml/xml_node_unittest.cc
+++ b/packager/mpd/base/xml/xml_node_unittest.cc
@@ -722,5 +722,41 @@ TEST_F(OnDemandVODSegmentTest, SegmentUrlWithMediaRanges) {
                    "</Representation>"));
 }
 
+class LowLatencySegmentTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    media_info_.set_init_segment_url("init.m4s");
+    media_info_.set_segment_template_url("$Number$.m4s");
+    media_info_.set_reference_time_scale(90000);
+    media_info_.set_availability_time_offset(4.900);
+    media_info_.set_segment_duration(450000);
+  }
+
+  MediaInfo media_info_;
+};
+
+TEST_F(LowLatencySegmentTest, LowLatencySegmentTemplate) {
+  const uint32_t kStartNumber = 1;
+  const uint64_t kDuration = 100;
+  const uint64_t kRepeat = 0;
+  const bool kIsLowLatency = true;
+
+    std::list<SegmentInfo> segment_infos = {
+      {kStartNumber, kDuration, kRepeat},
+  };
+  RepresentationXmlNode representation;
+  ASSERT_TRUE(representation.AddLiveOnlyInfo(media_info_, segment_infos,
+                                             kStartNumber, kIsLowLatency));
+  EXPECT_THAT(representation,
+              XmlNodeEqual(
+                  "<Representation>"
+                  "  <SegmentTemplate timescale=\"90000\" duration=\"450000\" "
+                  "                   availabilityTimeOffset=\"4.9\" "
+                  "                   initialization=\"init.m4s\" "
+                  "                   media=\"$Number$.m4s\" "
+                  "                   startNumber=\"1\"/>"
+                  "</Representation>"));
+}
+
 }  // namespace xml
 }  // namespace shaka

--- a/packager/mpd/base/xml/xml_node_unittest.cc
+++ b/packager/mpd/base/xml/xml_node_unittest.cc
@@ -368,13 +368,14 @@ TEST_F(LiveSegmentTimelineTest, OneSegmentInfo) {
   const int64_t kStartTime = 0;
   const int64_t kDuration = 100;
   const uint64_t kRepeat = 9;
+  const bool kIsLowLatency = false;
 
   std::list<SegmentInfo> segment_infos = {
       {kStartTime, kDuration, kRepeat},
   };
   RepresentationXmlNode representation;
   ASSERT_TRUE(
-      representation.AddLiveOnlyInfo(media_info_, segment_infos, kStartNumber));
+      representation.AddLiveOnlyInfo(media_info_, segment_infos, kStartNumber, kIsLowLatency));
 
   EXPECT_THAT(
       representation,
@@ -389,13 +390,14 @@ TEST_F(LiveSegmentTimelineTest, OneSegmentInfoNonZeroStartTime) {
   const int64_t kNonZeroStartTime = 500;
   const int64_t kDuration = 100;
   const uint64_t kRepeat = 9;
+  const bool kIsLowLatency = false;
 
   std::list<SegmentInfo> segment_infos = {
       {kNonZeroStartTime, kDuration, kRepeat},
   };
   RepresentationXmlNode representation;
   ASSERT_TRUE(
-      representation.AddLiveOnlyInfo(media_info_, segment_infos, kStartNumber));
+      representation.AddLiveOnlyInfo(media_info_, segment_infos, kStartNumber, kIsLowLatency));
 
   EXPECT_THAT(representation,
               XmlNodeEqual(
@@ -413,13 +415,14 @@ TEST_F(LiveSegmentTimelineTest, OneSegmentInfoMatchingStartTimeAndNumber) {
   const int64_t kNonZeroStartTime = 500;
   const int64_t kDuration = 100;
   const uint64_t kRepeat = 9;
+  const bool kIsLowLatency = false;
 
   std::list<SegmentInfo> segment_infos = {
       {kNonZeroStartTime, kDuration, kRepeat},
   };
   RepresentationXmlNode representation;
   ASSERT_TRUE(
-      representation.AddLiveOnlyInfo(media_info_, segment_infos, kStartNumber));
+      representation.AddLiveOnlyInfo(media_info_, segment_infos, kStartNumber, kIsLowLatency));
 
   EXPECT_THAT(
       representation,
@@ -431,6 +434,7 @@ TEST_F(LiveSegmentTimelineTest, OneSegmentInfoMatchingStartTimeAndNumber) {
 
 TEST_F(LiveSegmentTimelineTest, AllSegmentsSameDurationExpectLastOne) {
   const uint32_t kStartNumber = 1;
+  const bool kIsLowLatency = false;
 
   const int64_t kStartTime1 = 0;
   const int64_t kDuration1 = 100;
@@ -446,7 +450,7 @@ TEST_F(LiveSegmentTimelineTest, AllSegmentsSameDurationExpectLastOne) {
   };
   RepresentationXmlNode representation;
   ASSERT_TRUE(
-      representation.AddLiveOnlyInfo(media_info_, segment_infos, kStartNumber));
+      representation.AddLiveOnlyInfo(media_info_, segment_infos, kStartNumber, kIsLowLatency));
 
   EXPECT_THAT(
       representation,
@@ -458,6 +462,7 @@ TEST_F(LiveSegmentTimelineTest, AllSegmentsSameDurationExpectLastOne) {
 
 TEST_F(LiveSegmentTimelineTest, SecondSegmentInfoNonZeroRepeat) {
   const uint32_t kStartNumber = 1;
+  const bool kIsLowLatency = false;
 
   const int64_t kStartTime1 = 0;
   const int64_t kDuration1 = 100;
@@ -473,7 +478,7 @@ TEST_F(LiveSegmentTimelineTest, SecondSegmentInfoNonZeroRepeat) {
   };
   RepresentationXmlNode representation;
   ASSERT_TRUE(
-      representation.AddLiveOnlyInfo(media_info_, segment_infos, kStartNumber));
+      representation.AddLiveOnlyInfo(media_info_, segment_infos, kStartNumber, kIsLowLatency));
 
   EXPECT_THAT(representation,
               XmlNodeEqual(
@@ -489,6 +494,7 @@ TEST_F(LiveSegmentTimelineTest, SecondSegmentInfoNonZeroRepeat) {
 
 TEST_F(LiveSegmentTimelineTest, TwoSegmentInfoWithGap) {
   const uint32_t kStartNumber = 1;
+  const bool kIsLowLatency = false;
 
   const int64_t kStartTime1 = 0;
   const int64_t kDuration1 = 100;
@@ -505,7 +511,7 @@ TEST_F(LiveSegmentTimelineTest, TwoSegmentInfoWithGap) {
   };
   RepresentationXmlNode representation;
   ASSERT_TRUE(
-      representation.AddLiveOnlyInfo(media_info_, segment_infos, kStartNumber));
+      representation.AddLiveOnlyInfo(media_info_, segment_infos, kStartNumber, kIsLowLatency));
 
   EXPECT_THAT(representation,
               XmlNodeEqual(
@@ -524,6 +530,7 @@ TEST_F(LiveSegmentTimelineTest, LastSegmentNumberSupplementalProperty) {
   const int64_t kStartTime = 0;
   const int64_t kDuration = 100;
   const uint64_t kRepeat = 9;
+  const bool kIsLowLatency = false;
 
   std::list<SegmentInfo> segment_infos = {
       {kStartTime, kDuration, kRepeat},
@@ -532,7 +539,7 @@ TEST_F(LiveSegmentTimelineTest, LastSegmentNumberSupplementalProperty) {
   FLAGS_dash_add_last_segment_number_when_needed = true;
 
   ASSERT_TRUE(
-      representation.AddLiveOnlyInfo(media_info_, segment_infos, kStartNumber));
+      representation.AddLiveOnlyInfo(media_info_, segment_infos, kStartNumber, kIsLowLatency));
 
   EXPECT_THAT(
       representation,

--- a/packager/mpd/public/mpd_params.h
+++ b/packager/mpd/public/mpd_params.h
@@ -96,7 +96,7 @@ struct MpdParams {
   /// chunk. A chunk is the smallest unit and is constructed of a single moof
   /// and mdat atom. Each chunk is uploaded immediately upon creation,
   /// decoupling latency from segment duration.
-  bool is_low_latency_dash = false;
+  bool low_latency_dash_mode = false;
   /// This is the target latency in seconds requested by the user. The actual
   /// latency may be different to the target latency
   /// and is greatly influnced by the player.

--- a/packager/mpd/public/mpd_params.h
+++ b/packager/mpd/public/mpd_params.h
@@ -94,6 +94,11 @@ struct MpdParams {
   /// Use low latency dash streaming
   /// TODO(Caitlin): Elaborate
   bool is_low_latency_dash = false;
+  /// This is the target latency in seconds requested by the user. The actual 
+  /// latency may be different to the target latency 
+  /// and is greatly influnced by the player.
+  /// This parameter is required by DASH-IF Low Latency standards.
+  double target_latency_seconds = 1;
 };
 
 }  // namespace shaka

--- a/packager/mpd/public/mpd_params.h
+++ b/packager/mpd/public/mpd_params.h
@@ -91,7 +91,7 @@ struct MpdParams {
   /// content is huge and the total number of (sub)segment references
   /// is greater than what the sidx atom allows (65535).
   bool use_segment_list = false;
-  /// Use low latency dash streaming
+  /// Enable LL-DASH streaming
   /// TODO(Caitlin): Elaborate
   bool is_low_latency_dash = false;
   /// This is the target latency in seconds requested by the user. The actual 

--- a/packager/mpd/public/mpd_params.h
+++ b/packager/mpd/public/mpd_params.h
@@ -91,6 +91,9 @@ struct MpdParams {
   /// content is huge and the total number of (sub)segment references
   /// is greater than what the sidx atom allows (65535).
   bool use_segment_list = false;
+  /// Use low latency dash streaming
+  /// TODO(Caitlin): Elaborate
+  bool is_low_latency_dash = false;
 };
 
 }  // namespace shaka

--- a/packager/mpd/public/mpd_params.h
+++ b/packager/mpd/public/mpd_params.h
@@ -91,14 +91,14 @@ struct MpdParams {
   /// content is huge and the total number of (sub)segment references
   /// is greater than what the sidx atom allows (65535).
   bool use_segment_list = false;
-  /// Enable LL-DASH streaming. 
-  /// Each segment constists of many fragments, and each fragment contains one chunk.
-  /// A chunk is the smallest unit and is constructed of a single moof and mdat atom.
-  /// Each chunk is uploaded immediately upon creation,
-  /// decoupling latency from segment duration. 
+  /// Enable LL-DASH streaming.
+  /// Each segment constists of many fragments, and each fragment contains one
+  /// chunk. A chunk is the smallest unit and is constructed of a single moof
+  /// and mdat atom. Each chunk is uploaded immediately upon creation,
+  /// decoupling latency from segment duration.
   bool is_low_latency_dash = false;
-  /// This is the target latency in seconds requested by the user. The actual 
-  /// latency may be different to the target latency 
+  /// This is the target latency in seconds requested by the user. The actual
+  /// latency may be different to the target latency
   /// and is greatly influnced by the player.
   /// This parameter is required by DASH-IF Low Latency standards.
   double target_latency_seconds = 1;

--- a/packager/mpd/public/mpd_params.h
+++ b/packager/mpd/public/mpd_params.h
@@ -91,8 +91,11 @@ struct MpdParams {
   /// content is huge and the total number of (sub)segment references
   /// is greater than what the sidx atom allows (65535).
   bool use_segment_list = false;
-  /// Enable LL-DASH streaming
-  /// TODO(Caitlin): Elaborate
+  /// Enable LL-DASH streaming. 
+  /// Each segment constists of many fragments, and each fragment contains one chunk.
+  /// A chunk is the smallest unit and is constructed of a single moof and mdat atom.
+  /// Each chunk is uploaded immediately upon creation,
+  /// decoupling latency from segment duration. 
   bool is_low_latency_dash = false;
   /// This is the target latency in seconds requested by the user. The actual 
   /// latency may be different to the target latency 

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -374,6 +374,19 @@ Status ValidateParams(const PackagingParams& packaging_params,
                   "on-demand profile (not using segment_template or segment list).");
   }
 
+  if (packaging_params.chunking_params.is_low_latency_dash &&
+      packaging_params.chunking_params.subsegment_duration_in_seconds) {
+    // Low latency streaming requires data to be shipped as chunks,
+    // the smallest unit of video. Right now, each chunk contains
+    // one frame. Therefore, in low latency mode,
+    // a user specified --fragment_duration is irrelevant.
+    // TODO(caitlinocallaghan): Add a feature for users to specify the number
+    // of desired frames per chunk.
+    return Status(error::INVALID_ARGUMENT,
+                  "--fragment_duration cannot be set "
+                  "if --is_low_latency_dash is enabled.");
+  }
+
   return Status::OK;
 }
 

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -374,7 +374,7 @@ Status ValidateParams(const PackagingParams& packaging_params,
                   "on-demand profile (not using segment_template or segment list).");
   }
 
-  if (packaging_params.chunking_params.is_low_latency_dash &&
+  if (packaging_params.chunking_params.low_latency_dash_mode &&
       packaging_params.chunking_params.subsegment_duration_in_seconds) {
     // Low latency streaming requires data to be shipped as chunks,
     // the smallest unit of video. Right now, each chunk contains
@@ -384,15 +384,15 @@ Status ValidateParams(const PackagingParams& packaging_params,
     // of desired frames per chunk.
     return Status(error::INVALID_ARGUMENT,
                   "--fragment_duration cannot be set "
-                  "if --is_low_latency_dash is enabled.");
+                  "if --low_latency_dash_mode is enabled.");
   }
 
-  if (packaging_params.mpd_params.is_low_latency_dash &&
+  if (packaging_params.mpd_params.low_latency_dash_mode &&
       packaging_params.mpd_params.utc_timings.empty()) {
     // Low latency DASH MPD requires a UTC Timing value
     return Status(error::INVALID_ARGUMENT,
                   "--utc_timings must be be set "
-                  "if --is_low_latency_dash is enabled.");
+                  "if --low_latency_dash_mode is enabled.");
   }
 
   return Status::OK;

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -387,6 +387,14 @@ Status ValidateParams(const PackagingParams& packaging_params,
                   "if --is_low_latency_dash is enabled.");
   }
 
+  if (packaging_params.mpd_params.is_low_latency_dash && 
+      packaging_params.mpd_params.utc_timings.empty()) {
+    // Low latency DASH MPD requires a UTC Timing value
+    return Status(error::INVALID_ARGUMENT,
+                  "--utc_timings must be be set "
+                  "if --is_low_latency_dash is enabled.");
+  }
+
   return Status::OK;
 }
 

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -387,7 +387,7 @@ Status ValidateParams(const PackagingParams& packaging_params,
                   "if --is_low_latency_dash is enabled.");
   }
 
-  if (packaging_params.mpd_params.is_low_latency_dash && 
+  if (packaging_params.mpd_params.is_low_latency_dash &&
       packaging_params.mpd_params.utc_timings.empty()) {
     // Low latency DASH MPD requires a UTC Timing value
     return Status(error::INVALID_ARGUMENT,

--- a/packager/packager_test.cc
+++ b/packager/packager_test.cc
@@ -277,6 +277,16 @@ TEST_F(PackagerTest, LowLatencyDashEnabledAndFragmentDurationSet) {
   EXPECT_THAT(status.error_message(),
               HasSubstr("--fragment_duration cannot be set"));
 }
+
+TEST_F(PackagerTest, LowLatencyDashEnabledAndUtcTimingNotSet) {
+  auto packaging_params = SetupPackagingParams();
+  packaging_params.mpd_params.is_low_latency_dash = true;
+  Packager packager;
+  auto status = packager.Initialize(packaging_params, SetupStreamDescriptors());
+  ASSERT_EQ(error::INVALID_ARGUMENT, status.error_code());
+  EXPECT_THAT(status.error_message(),
+              HasSubstr("--utc_timings must be be set"));
+}
 // TODO(kqyang): Add more tests.
 
 }  // namespace shaka

--- a/packager/packager_test.cc
+++ b/packager/packager_test.cc
@@ -269,7 +269,7 @@ TEST_F(PackagerTest, ReadFromBufferFailed) {
 
 TEST_F(PackagerTest, LowLatencyDashEnabledAndFragmentDurationSet) {
   auto packaging_params = SetupPackagingParams();
-  packaging_params.chunking_params.is_low_latency_dash = true;
+  packaging_params.chunking_params.low_latency_dash_mode = true;
   packaging_params.chunking_params.subsegment_duration_in_seconds =
       kFragmentDurationInSeconds;
   Packager packager;
@@ -281,7 +281,7 @@ TEST_F(PackagerTest, LowLatencyDashEnabledAndFragmentDurationSet) {
 
 TEST_F(PackagerTest, LowLatencyDashEnabledAndUtcTimingNotSet) {
   auto packaging_params = SetupPackagingParams();
-  packaging_params.mpd_params.is_low_latency_dash = true;
+  packaging_params.mpd_params.low_latency_dash_mode = true;
   Packager packager;
   auto status = packager.Initialize(packaging_params, SetupStreamDescriptors());
   ASSERT_EQ(error::INVALID_ARGUMENT, status.error_code());

--- a/packager/packager_test.cc
+++ b/packager/packager_test.cc
@@ -270,7 +270,8 @@ TEST_F(PackagerTest, ReadFromBufferFailed) {
 TEST_F(PackagerTest, LowLatencyDashEnabledAndFragmentDurationSet) {
   auto packaging_params = SetupPackagingParams();
   packaging_params.chunking_params.is_low_latency_dash = true;
-  packaging_params.chunking_params.subsegment_duration_in_seconds = kFragmentDurationInSeconds; 
+  packaging_params.chunking_params.subsegment_duration_in_seconds =
+      kFragmentDurationInSeconds;
   Packager packager;
   auto status = packager.Initialize(packaging_params, SetupStreamDescriptors());
   ASSERT_EQ(error::INVALID_ARGUMENT, status.error_code());

--- a/packager/packager_test.cc
+++ b/packager/packager_test.cc
@@ -39,6 +39,7 @@ const uint8_t kKey[]{
     0x3a, 0xed, 0xde, 0xc0, 0xbc, 0x42, 0x1f, 0x4d,
 };
 const double kClearLeadInSeconds = 1.0;
+const double kFragmentDurationInSeconds = 5.0;
 
 }  // namespace
 
@@ -266,6 +267,16 @@ TEST_F(PackagerTest, ReadFromBufferFailed) {
   ASSERT_EQ(error::FILE_FAILURE, packager.Run().error_code());
 }
 
+TEST_F(PackagerTest, LowLatencyDashEnabledAndFragmentDurationSet) {
+  auto packaging_params = SetupPackagingParams();
+  packaging_params.chunking_params.is_low_latency_dash = true;
+  packaging_params.chunking_params.subsegment_duration_in_seconds = kFragmentDurationInSeconds; 
+  Packager packager;
+  auto status = packager.Initialize(packaging_params, SetupStreamDescriptors());
+  ASSERT_EQ(error::INVALID_ARGUMENT, status.error_code());
+  EXPECT_THAT(status.error_message(),
+              HasSubstr("--fragment_duration cannot be set"));
+}
 // TODO(kqyang): Add more tests.
 
 }  // namespace shaka


### PR DESCRIPTION
# LL-DASH Support
These changes add support for LL-DASH streaming. 
While writing this feature, I have been checking in with @joeyparrish to get feedback along the way. See the original PRs [here](https://github.com/CaitlinOCallaghan/shaka-packager/pulls?q=is%3Apr+is%3Aclosed). 


**NOTE:** LL-HLS support is still in progress, but it's coming. :) 
## Testing
`./chunking_unittest --gtest_filter="ChunkingHandlerTest.LowLatencyDash"`

`./media_event_unittest --gtest_filter="MpdNotifyMuxerListenerTest.LowLatencyDash"`

`./mpd_unittest --gtest_filter="PeriodTest.LowLatencyDashMpdGetXml"`
`./mpd_unittest --gtest_filter="SimpleMpdNotifierTest.NotifyAvailabilityTimeOffset"`
`./mpd_unittest --gtest_filter="SimpleMpdNotifierTest.NotifySegmentDuration"`
`./mpd_unittest --gtest_filter="LowLatencySegmentTest.LowLatencySegmentTemplate"`

Note, packager_test must be run from the main project directory
`./out/Release/packager_test --gtest_filter="PackagerTest.LowLatencyDashEnabledAndUtcTimingNotSet"`
`./out/Release/packager_test --gtest_filter="PackagerTest.LowLatencyDashEnabledAndUtcTimingNotSet"`

## Documentation
![image](https://user-images.githubusercontent.com/38890251/129788178-b4a44368-6cca-45f6-a4cf-91233aa2bb56.png)
![image](https://user-images.githubusercontent.com/38890251/129815238-0648feb6-6877-4818-bcf8-f6612c5ca9de.png)
