### PR TITLE
Fix for gap size warning in Low Latency mode

### DIFF
--- a/packager/media/event/combined_muxer_listener.cc
+++ b/packager/media/event/combined_muxer_listener.cc
@@ -77,6 +77,13 @@ void CombinedMuxerListener::OnNewSegment(const std::string& file_name,
   }
 }
 
+void CombinedMuxerListener::OnCompletedSegment(int64_t duration,
+                                               uint64_t segment_file_size) {
+  for (auto& listener : muxer_listeners_) {
+    listener->OnCompletedSegment(duration, segment_file_size);
+  }
+}
+
 void CombinedMuxerListener::OnKeyFrame(int64_t timestamp,
                                        uint64_t start_byte_offset,
                                        uint64_t size) {

--- a/packager/media/event/combined_muxer_listener.h
+++ b/packager/media/event/combined_muxer_listener.h
@@ -45,6 +45,8 @@ class CombinedMuxerListener : public MuxerListener {
                     int64_t start_time,
                     int64_t duration,
                     uint64_t segment_file_size) override;
+  void OnCompletedSegment(int64_t duration,
+                          uint64_t segment_file_size) override;
   void OnKeyFrame(int64_t timestamp, uint64_t start_byte_offset, uint64_t size);
   void OnCueEvent(int64_t timestamp, const std::string& cue_data) override;
   /// @}

--- a/packager/media/event/mpd_notify_muxer_listener.cc
+++ b/packager/media/event/mpd_notify_muxer_listener.cc
@@ -204,6 +204,12 @@ void MpdNotifyMuxerListener::OnNewSegment(const std::string& file_name,
   }
 }
 
+void MpdNotifyMuxerListener::OnCompletedSegment(int64_t duration,
+                                                uint64_t segment_file_size) {
+  mpd_notifier_->NotifyCompletedSegment(notification_id_.value(), duration,
+                                        segment_file_size);
+}
+
 void MpdNotifyMuxerListener::OnKeyFrame(int64_t timestamp,
                                         uint64_t start_byte_offset,
                                         uint64_t size) {

--- a/packager/media/event/mpd_notify_muxer_listener.h
+++ b/packager/media/event/mpd_notify_muxer_listener.h
@@ -53,6 +53,8 @@ class MpdNotifyMuxerListener : public MuxerListener {
                     int64_t start_time,
                     int64_t duration,
                     uint64_t segment_file_size) override;
+  void OnCompletedSegment(int64_t duration,
+                          uint64_t segment_file_size) override;
   void OnKeyFrame(int64_t timestamp, uint64_t start_byte_offset, uint64_t size);
   void OnCueEvent(int64_t timestamp, const std::string& cue_data) override;
   /// @}

--- a/packager/media/event/muxer_listener.h
+++ b/packager/media/event/muxer_listener.h
@@ -135,6 +135,10 @@ class MuxerListener {
                             int64_t duration,
                             uint64_t segment_file_size) = 0;
 
+  /// TODO(Caitlin)
+  virtual void OnCompletedSegment(int64_t duration,
+                                  uint64_t segment_file_size) {}
+
   /// Called when there is a new key frame. For Video only. Note that it should
   /// be called before OnNewSegment is called on the containing segment.
   /// @param timestamp is in terms of the timescale of the media.

--- a/packager/media/event/muxer_listener.h
+++ b/packager/media/event/muxer_listener.h
@@ -120,9 +120,11 @@ class MuxerListener {
                           float duration_seconds) = 0;
 
   /// Called when a segment has been muxed and the file has been written.
-  /// Note: For some implementations, this is used to signal new subsegments.
-  /// For example, for generating video on demand (VOD) MPD manifest, this is
-  /// called to signal subsegments.
+  /// Note: For some implementations, this is used to signal new subsegments
+  /// or chunks. For example, for generating video on demand (VOD) MPD manifest,
+  /// this is called to signal subsegments. In the low latency case, this
+  /// indicates the start of a new segment and will contain info about the
+  /// segment's first chunk.
   /// @param segment_name is the name of the new segment. Note that some
   ///        implementations may not require this, e.g. if this is a subsegment.
   /// @param start_time is the start time of the segment, relative to the
@@ -135,7 +137,12 @@ class MuxerListener {
                             int64_t duration,
                             uint64_t segment_file_size) = 0;
 
-  /// TODO(Caitlin)
+  /// Called when a segment has been muxed and the entire file has been written.
+  /// For Low Latency only. Note that it should be called after OnNewSegment.
+  /// When the low latency segment is initally added to the manifest, the size
+  /// and duration are not known, because the segment is still being processed.
+  /// This will update the segment's duration and size after the segment is
+  /// fully written and these values are known.
   virtual void OnCompletedSegment(int64_t duration,
                                   uint64_t segment_file_size) {}
 

--- a/packager/media/formats/mp4/low_latency_segment_segmenter.h
+++ b/packager/media/formats/mp4/low_latency_segment_segmenter.h
@@ -61,6 +61,7 @@ class LowLatencySegmentSegmenter : public Segmenter {
   bool ll_dash_mpd_values_initialized_ = false;
   std::unique_ptr<File, FileCloser> segment_file_;
   std::string file_name_;
+  size_t segment_size_ = 0u;
 
   DISALLOW_COPY_AND_ASSIGN(LowLatencySegmentSegmenter);
 };

--- a/packager/mpd/base/mock_mpd_notifier.h
+++ b/packager/mpd/base/mock_mpd_notifier.h
@@ -31,6 +31,8 @@ class MockMpdNotifier : public MpdNotifier {
                     int64_t start_time,
                     int64_t duration,
                     uint64_t size));
+  MOCK_METHOD3(NotifyCompletedSegment,
+               bool(uint32_t container_id, int64_t duration, uint64_t size));
   MOCK_METHOD1(NotifyAvailabilityTimeOffset, bool(uint32_t container_id));
   MOCK_METHOD1(NotifySegmentDuration, bool(uint32_t container_id));
   MOCK_METHOD2(NotifyCueEvent, bool(uint32_t container_id, int64_t timestamp));

--- a/packager/mpd/base/mpd_notifier.h
+++ b/packager/mpd/base/mpd_notifier.h
@@ -73,7 +73,8 @@ class MpdNotifier {
   virtual bool NotifySegmentDuration(uint32_t container_id) { return true; }
 
   /// Notifies MpdBuilder that there is a new segment ready. For live, this
-  /// is usually a new segment, for VOD this is usually a subsegment.
+  /// is usually a new segment, for VOD this is usually a subsegment, for low
+  /// latency this is the first chunk.
   /// @param container_id Container ID obtained from calling
   ///        NotifyNewContainer().
   /// @param start_time is the start time of the new segment, in units of the
@@ -87,7 +88,17 @@ class MpdNotifier {
                                 int64_t duration,
                                 uint64_t size) = 0;
 
-  /// TODO(Caitlin)
+  /// Notifies MpdBuilder that a segment is fully written and provides the
+  /// segment's complete duration and size. For Low Latency only. Note, size and
+  /// duration are not known when the low latency segment is first registered
+  /// with the MPD, so we must update these values after the segment is
+  /// complete.
+  /// @param container_id Container ID obtained from calling
+  ///        NotifyNewContainer().
+  /// @param duration is the duration of the complete segment, in units of the
+  ///        stream's time scale.
+  /// @param size is the complete segment size in bytes.
+  /// @return true on success, false otherwise.
   virtual bool NotifyCompletedSegment(uint32_t container_id,
                                       int64_t duration,
                                       uint64_t size) {

--- a/packager/mpd/base/mpd_notifier.h
+++ b/packager/mpd/base/mpd_notifier.h
@@ -87,6 +87,13 @@ class MpdNotifier {
                                 int64_t duration,
                                 uint64_t size) = 0;
 
+  /// TODO(Caitlin)
+  virtual bool NotifyCompletedSegment(uint32_t container_id,
+                                      int64_t duration,
+                                      uint64_t size) {
+    return true;
+  }
+
   /// Notifies MpdBuilder that there is a new CueEvent.
   /// @param container_id Container ID obtained from calling
   ///        NotifyNewContainer().

--- a/packager/mpd/base/representation.cc
+++ b/packager/mpd/base/representation.cc
@@ -187,6 +187,22 @@ void Representation::AddNewSegment(int64_t start_time,
     state_change_listener_->OnNewSegmentForRepresentation(start_time, duration);
 
   AddSegmentInfo(start_time, duration);
+
+  // Only update the buffer depth and bandwidth estimator when the full segment
+  // is completed. In the LL-DASH case, only the first chunk in the segment has
+  // been written at this point. For LL-DASH, wait until the entire segment has
+  // been written before updating.
+  if (!mpd_options_.mpd_params.low_latency_dash_mode) {
+    current_buffer_depth_ += segment_infos_.back().duration;
+
+    bandwidth_estimator_.AddBlock(size, static_cast<double>(duration) /
+                                            media_info_.reference_time_scale());
+  }
+}
+
+void Representation::UpdateCompletedSegment(int64_t duration, uint64_t size) {
+  UpdateSegmentInfo(duration);
+
   current_buffer_depth_ += segment_infos_.back().duration;
 
   bandwidth_estimator_.AddBlock(
@@ -408,6 +424,13 @@ void Representation::AddSegmentInfo(int64_t start_time, int64_t duration) {
   }
 
   segment_infos_.push_back({start_time, adjusted_duration, kNoRepeat});
+}
+
+void Representation::UpdateSegmentInfo(int64_t duration) {
+  if (!segment_infos_.empty()) {
+    // Update the duration in the current segment.
+    segment_infos_.back().duration = duration;
+  }
 }
 
 bool Representation::ApproximiatelyEqual(int64_t time1, int64_t time2) const {

--- a/packager/mpd/base/representation.cc
+++ b/packager/mpd/base/representation.cc
@@ -189,9 +189,10 @@ void Representation::AddNewSegment(int64_t start_time,
   AddSegmentInfo(start_time, duration);
 
   // Only update the buffer depth and bandwidth estimator when the full segment
-  // is completed. In the LL-DASH case, only the first chunk in the segment has
-  // been written at this point. For LL-DASH, wait until the entire segment has
-  // been written before updating.
+  // is completed. In the low latency case, only the first chunk in the segment
+  // has been written at this point. Therefore, we must wait until the entire
+  // segment has been written before updating buffer depth and bandwidth
+  // estimator.
   if (!mpd_options_.mpd_params.low_latency_dash_mode) {
     current_buffer_depth_ += segment_infos_.back().duration;
 
@@ -201,6 +202,12 @@ void Representation::AddNewSegment(int64_t start_time,
 }
 
 void Representation::UpdateCompletedSegment(int64_t duration, uint64_t size) {
+  if (!mpd_options_.mpd_params.low_latency_dash_mode) {
+    LOG(WARNING)
+        << "UpdateCompletedSegment is only applicable to low latency mode.";
+    return;
+  }
+
   UpdateSegmentInfo(duration);
 
   current_buffer_depth_ += segment_infos_.back().duration;

--- a/packager/mpd/base/representation.h
+++ b/packager/mpd/base/representation.h
@@ -97,7 +97,9 @@ class Representation {
   /// @param duration is the duration of the segment, in units of the stream's
   ///        time scale. In the low latency case, this duration is that of the
   ///        first chunk because the full duration is not yet known.
-  /// @param size of the segment in bytes.
+  /// @param size of the segment in bytes. In the low latency case, this size is
+  /// that of the
+  ///        first chunk because the full size is not yet known.
   virtual void AddNewSegment(int64_t start_time,
                              int64_t duration,
                              uint64_t size);
@@ -106,9 +108,10 @@ class Representation {
   /// In the low latency case, the segment duration will not be ready until the
   /// entire segment has been processed. This allows setting the full duration
   /// after the segment has been completed and the true duratio is known.
-  /// @param duration is the duration of the segment, in units of the stream's
+  /// @param duration is the duration of the complete segment, in units of the
+  /// stream's
   ///        time scale.
-  /// @param size of the segment in bytes.
+  /// @param size of the complete segment in bytes.
   virtual void UpdateCompletedSegment(int64_t duration, uint64_t size);
 
   /// Set the sample duration of this Representation.
@@ -199,8 +202,8 @@ class Representation {
   void AddSegmentInfo(int64_t start_time, int64_t duration);
 
   // Update the current SegmentInfo. This method is used to update the duration
-  // value after a low latency segment has been completed and the true duration
-  // is known.
+  // value after a low latency segment is complete, and the full segment
+  // duration is known.
   void UpdateSegmentInfo(int64_t duration);
 
   // Check if two timestamps are approximately equal if

--- a/packager/mpd/base/representation.h
+++ b/packager/mpd/base/representation.h
@@ -95,11 +95,21 @@ class Representation {
   /// @param start_time is the start time for the (sub)segment, in units of the
   ///        stream's time scale.
   /// @param duration is the duration of the segment, in units of the stream's
-  ///        time scale.
+  ///        time scale. In the low latency case, this duration is that of the
+  ///        first chunk because the full duration is not yet known.
   /// @param size of the segment in bytes.
   virtual void AddNewSegment(int64_t start_time,
                              int64_t duration,
                              uint64_t size);
+
+  /// Update a media segment in the Representation.
+  /// In the low latency case, the segment duration will not be ready until the
+  /// entire segment has been processed. This allows setting the full duration
+  /// after the segment has been completed and the true duratio is known.
+  /// @param duration is the duration of the segment, in units of the stream's
+  ///        time scale.
+  /// @param size of the segment in bytes.
+  virtual void UpdateCompletedSegment(int64_t duration, uint64_t size);
 
   /// Set the sample duration of this Representation.
   /// Sample duration is not available right away especially for live. This
@@ -187,6 +197,11 @@ class Representation {
   // Add a SegmentInfo. This function may insert an adjusted SegmentInfo if
   // |allow_approximate_segment_timeline_| is set.
   void AddSegmentInfo(int64_t start_time, int64_t duration);
+
+  // Update the current SegmentInfo. This method is used to update the duration
+  // value after a low latency segment has been completed and the true duration
+  // is known.
+  void UpdateSegmentInfo(int64_t duration);
 
   // Check if two timestamps are approximately equal if
   // |allow_approximate_segment_timeline_| is set; Otherwise check whether the

--- a/packager/mpd/base/representation_unittest.cc
+++ b/packager/mpd/base/representation_unittest.cc
@@ -462,10 +462,10 @@ class SegmentTemplateTest : public RepresentationTest {
     segment_infos_for_expected_out_.push_back(s);
 
     if (mpd_options_.mpd_params.low_latency_dash_mode) {
-      // Low Latency segments do not repeat, so create 1 new segment and return.
-      // At this point, only one chunk has been written.
-      // The BW will be updated once segment is fully written, and the duration
-      // is known.
+      // Low latency segments do not repeat, so create 1 new segment and return.
+      // At this point, only the first chunk of the low latency segment has been
+      // written. The BW will be updated once the segment is fully written and
+      // the segment duration and size are known.
       representation_->AddNewSegment(start_time, duration, size);
       return;
     }

--- a/packager/mpd/base/representation_unittest.cc
+++ b/packager/mpd/base/representation_unittest.cc
@@ -464,8 +464,8 @@ class SegmentTemplateTest : public RepresentationTest {
     if (mpd_options_.mpd_params.low_latency_dash_mode) {
       // Low latency segments do not repeat, so create 1 new segment and return.
       // At this point, only the first chunk of the low latency segment has been
-      // written. The BW will be updated once the segment is fully written and
-      // the segment duration and size are known.
+      // written. The bandwidth will be updated once the segment is fully
+      // written and the segment duration and size are known.
       representation_->AddNewSegment(start_time, duration, size);
       return;
     }

--- a/packager/mpd/base/simple_mpd_notifier.cc
+++ b/packager/mpd/base/simple_mpd_notifier.cc
@@ -119,6 +119,19 @@ bool SimpleMpdNotifier::NotifyNewSegment(uint32_t container_id,
   return true;
 }
 
+bool SimpleMpdNotifier::NotifyCompletedSegment(uint32_t container_id,
+                                               int64_t duration,
+                                               uint64_t size) {
+  base::AutoLock auto_lock(lock_);
+  auto it = representation_map_.find(container_id);
+  if (it == representation_map_.end()) {
+    LOG(ERROR) << "Unexpected container_id: " << container_id;
+    return false;
+  }
+  it->second->UpdateCompletedSegment(duration, size);
+  return true;
+}
+
 bool SimpleMpdNotifier::NotifyCueEvent(uint32_t container_id,
                                        int64_t timestamp) {
   base::AutoLock auto_lock(lock_);

--- a/packager/mpd/base/simple_mpd_notifier.h
+++ b/packager/mpd/base/simple_mpd_notifier.h
@@ -44,6 +44,9 @@ class SimpleMpdNotifier : public MpdNotifier {
                         int64_t start_time,
                         int64_t duration,
                         uint64_t size) override;
+  bool NotifyCompletedSegment(uint32_t container_id,
+                              int64_t duration,
+                              uint64_t size) override;
   bool NotifyCueEvent(uint32_t container_id, int64_t timestamp) override;
   bool NotifyEncryptionUpdate(uint32_t container_id,
                               const std::string& drm_uuid,


### PR DESCRIPTION
## The issue
- With LL-DASH mode enabled, the gap size warning was hit and printed to the console every time a new segment was registered to the manifest.
- This occurred because the first chunk's size and duration were being stored for each segment, rather than the full segment size and duration. Note, only the first chunk's metrics are known at first because in low latency mode, the segment is registered to the manifest before it is finished being processed and written.
- Because of this, the gap size check was comparing the end time of the first chunk in the previous segment to the beginning time of the current segment, causing the check to fail every time.

## The Fix
- Update a low latency segment's duration and size once the segment file has been fully written.
- The full segment size and duration will be used to update the bandwidth estimator and the segment info list. 
- Updating the segment info list to hold the full duration is necessary for satisfying [the gap size check found in Represenation.cc](https://github.com/google/shaka-packager/blob/master/packager/mpd/base/representation.cc#L391).
- NOTE: bandwidth estimation is currently only used in HLS

## Testing
- `./mpd_unittest --gtest_filter="SegmentTemplateTest.OneSegmentLowLatency"`
![image](https://user-images.githubusercontent.com/38890251/131379038-d956eddc-80b2-4aaa-8d81-443f7df67967.png)

- manual
![image](https://user-images.githubusercontent.com/38890251/131379006-21db3a4a-9f4b-431d-88dc-7a850fbb5e70.png)
