### PR TITLE
fix: handle EEXIST error in directory creation

### DIFF
--- a/packager/file/file_unittest.cc
+++ b/packager/file/file_unittest.cc
@@ -313,7 +313,8 @@ TEST_F(LocalFileTest, WriteInDirectory) {
   EXPECT_EQ(data_, read_data);
 
   // Wipe the folder.
-  std::filesystem::remove_all(std::filesystem::u8path(temp_folder));
+  std::error_code ec;
+  std::filesystem::remove_all(std::filesystem::u8path(temp_folder), ec);
 }
 
 class ParamLocalFileTest : public LocalFileTest,

--- a/packager/file/file_unittest.cc
+++ b/packager/file/file_unittest.cc
@@ -83,10 +83,7 @@ class LocalFileTest : public testing::Test {
       data_[i] = i % 256;
 
     local_file_name_no_prefix_ = generate_unique_temp_path();
-
-    // Local file name with prefix for File API.
-    local_file_name_ = kLocalFilePrefix;
-    local_file_name_ += local_file_name_no_prefix_;
+    RecomputeLocalFileName();
 
     // Use LocalFile directly without ThreadedIoFile.
     backup_io_cache_size.reset(new FlagSaver<uint64_t>(&FLAGS_io_cache_size));
@@ -96,6 +93,12 @@ class LocalFileTest : public testing::Test {
   void TearDown() override {
     // Remove test file if created.
     DeleteFile(local_file_name_no_prefix_);
+  }
+
+  void RecomputeLocalFileName() {
+    // Local file name with prefix for File API.
+    local_file_name_ = kLocalFilePrefix;
+    local_file_name_ += local_file_name_no_prefix_;
   }
 
   std::unique_ptr<FlagSaver<uint64_t>> backup_io_cache_size;
@@ -255,8 +258,8 @@ TEST_F(LocalFileTest, UnicodePath) {
   // Modify the local file name for this test to include non-ASCII characters.
   // This is used in TearDown() to clean up the file we create in the test.
   const std::string unicode_suffix = "από.txt";
-  local_file_name_ += unicode_suffix;
   local_file_name_no_prefix_ += unicode_suffix;
+  RecomputeLocalFileName();
 
   // Write file using File API.
   File* file = File::Open(local_file_name_.c_str(), "w");
@@ -279,6 +282,28 @@ TEST_F(LocalFileTest, UnicodePath) {
   uint8_t single_byte;
   EXPECT_EQ(0, file->Read(&single_byte, sizeof(single_byte)));
   ASSERT_TRUE(file->Close());
+
+  // Compare data written and read.
+  EXPECT_EQ(data_, read_data);
+}
+
+TEST_F(LocalFileTest, WriteInDirectory) {
+  // Adjust the file names to include a directory.
+  // It should be automatically created.
+  local_file_name_no_prefix_ = "some_dir/" + local_file_name_no_prefix_;
+  RecomputeLocalFileName();
+
+  // Write file using File API.
+  File* file = File::Open(local_file_name_.c_str(), "w");
+  ASSERT_TRUE(file != NULL);
+  EXPECT_EQ(kDataSize, file->Write(&data_[0], kDataSize));
+  EXPECT_EQ(kDataSize, file->Size());
+  EXPECT_TRUE(file->Close());
+
+  std::string read_data;
+  ASSERT_EQ(kDataSize, FileSize(local_file_name_no_prefix_));
+  ASSERT_EQ(kDataSize,
+            ReadFile(local_file_name_no_prefix_, &read_data, kDataSize));
 
   // Compare data written and read.
   EXPECT_EQ(data_, read_data);

--- a/packager/file/file_unittest.cc
+++ b/packager/file/file_unittest.cc
@@ -288,12 +288,16 @@ TEST_F(LocalFileTest, UnicodePath) {
 }
 
 TEST_F(LocalFileTest, WriteInDirectory) {
-  // Adjust the file names to include a directory.
-  // It should be automatically created.
-  local_file_name_no_prefix_ = "some_dir/" + local_file_name_no_prefix_;
+  // Delete the temp file.
+  DeleteFile(local_file_name_no_prefix_);
+  // Treat that unique name as a temp folder which doesn't exist.
+  const std::string temp_folder = local_file_name_no_prefix_;
+  // Adjust the filename to include that folder.
+  local_file_name_no_prefix_ = temp_folder + "/foo.txt";
   RecomputeLocalFileName();
 
   // Write file using File API.
+  // The folder should be automatically created.
   File* file = File::Open(local_file_name_.c_str(), "w");
   ASSERT_TRUE(file != NULL);
   EXPECT_EQ(kDataSize, file->Write(&data_[0], kDataSize));
@@ -307,6 +311,9 @@ TEST_F(LocalFileTest, WriteInDirectory) {
 
   // Compare data written and read.
   EXPECT_EQ(data_, read_data);
+
+  // Wipe the folder.
+  std::filesystem::remove_all(std::filesystem::u8path(temp_folder));
 }
 
 class ParamLocalFileTest : public LocalFileTest,

--- a/packager/file/local_file.cc
+++ b/packager/file/local_file.cc
@@ -126,7 +126,10 @@ bool LocalFile::Open() {
     std::error_code ec;
     if (parent_path != "" && !std::filesystem::is_directory(parent_path, ec)) {
       if (!std::filesystem::create_directories(parent_path, ec)) {
-        return false;
+        if (ec) {  // Only fail if there's an actual error
+          return false;
+        }
+        // ec is empty means directory already exists - continue normally
       }
     }
   }


### PR DESCRIPTION
  Fix incorrect error handling in `LocalFile::Open()` when `create_directories()` encounters an already-existing directory.

  ### Problem

  The current code treats `create_directories()` returning `false` as a failure:

  ```cpp
  if (!std::filesystem::create_directories(parent_path, ec)) {
    return false;  // BUG: ec is not checked
  }
  ```

  However, according to the C++ standard, [std::filesystem::create_directories()](https://en.cppreference.com/w/cpp/filesystem/create_directory.html):
  - Returns true if a new directory was created
  - Returns false with ec.clear() if the directory already exists (not an error)
  - Returns false with ec set if an actual error occurred

  This causes failures in several scenarios:
  1. Concurrent packaging: Multiple threads creating the same output directory
  2. External directory creation: Another process creates the directory between is_directory() check and create_directories()
  call
  3. Retry after partial failure: Directory was created in a previous failed attempt

  ### Example Failure (strace)

  ```bash
  newfstatat("/tmp/out/dir") = -1 ENOENT      ← Directory doesn't exist
  mkdirat("/tmp/out/dir", 0777) = -1 EEXIST   ← Created by another process/thread
  exit(0)                                      ← Packager exits without writing output
  ```

  The directory exists and is ready to use, but the code incorrectly treats this as a failure.

###  Solution

  Check the error_code after create_directories() returns false. Only return failure if ec indicates an actual error.

  ```cpp
  if (!std::filesystem::create_directories(parent_path, ec)) {
    if (ec) {  // Only fail if there's an actual error
      return false;
    }
    // ec is empty means directory already exists - continue normally
  }
  ```