### PR TITLE
feat: Switch EVENT/Live streams to VOD when the event ends

### DIFF
--- a/packager/hls/base/hls_notifier.h
+++ b/packager/hls/base/hls_notifier.h
@@ -97,6 +97,8 @@ class HlsNotifier {
       const std::vector<uint8_t>& iv,
       const std::vector<uint8_t>& protection_system_specific_data) = 0;
 
+  virtual bool NotifyEndOfStream() = 0;
+
   /// Process any current buffered states/resources.
   /// @return true on success, false otherwise.
   virtual bool Flush() = 0;

--- a/packager/hls/base/media_playlist.cc
+++ b/packager/hls/base/media_playlist.cc
@@ -510,20 +510,25 @@ void MediaPlaylist::AddPlacementOpportunity() {
   entries_.emplace_back(new PlacementOpportunityEntry());
 }
 
-bool MediaPlaylist::WriteToFile(const std::filesystem::path& file_path) {
+bool MediaPlaylist::WriteToFile(const std::filesystem::path& file_path, const bool endStream) {
   if (!target_duration_set_) {
     SetTargetDuration(ceil(GetLongestSegmentDuration()));
   }
 
+  HlsPlaylistType playlist_type = hls_params_.playlist_type;
+  if (endStream && playlist_type == HlsPlaylistType::kLive) {
+	  playlist_type = HlsPlaylistType::kVod;
+  }
+
   std::string content = CreatePlaylistHeader(
-      media_info_, target_duration_, hls_params_.playlist_type, stream_type_,
+      media_info_, target_duration_, playlist_type, stream_type_,
       media_sequence_number_, discontinuity_sequence_number_,
       hls_params_.start_time_offset);
 
   for (const auto& entry : entries_)
     absl::StrAppendFormat(&content, "%s\n", entry->ToString().c_str());
 
-  if (hls_params_.playlist_type == HlsPlaylistType::kVod) {
+  if (endStream) {
     content += "#EXT-X-ENDLIST\n";
   }
 

--- a/packager/hls/base/media_playlist.h
+++ b/packager/hls/base/media_playlist.h
@@ -185,7 +185,7 @@ class MediaPlaylist {
   /// @param file_path is the output file path accepted by the File
   ///        implementation.
   /// @return true on success, false otherwise.
-  virtual bool WriteToFile(const std::filesystem::path& file_path);
+  virtual bool WriteToFile(const std::filesystem::path& file_path, bool endStream);
 
   /// If bitrate is specified in MediaInfo then it will use that value.
   /// Otherwise, returns the max bitrate.

--- a/packager/hls/base/media_playlist_unittest.cc
+++ b/packager/hls/base/media_playlist_unittest.cc
@@ -170,7 +170,7 @@ TEST_F(MediaPlaylistSingleSegmentTest, InitRange) {
 
   ASSERT_TRUE(media_playlist_->SetMediaInfo(valid_video_media_info_));
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -190,7 +190,7 @@ TEST_F(MediaPlaylistSingleSegmentTest, InitRangeWithOffset) {
 
   ASSERT_TRUE(media_playlist_->SetMediaInfo(valid_video_media_info_));
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -224,7 +224,7 @@ TEST_F(MediaPlaylistSingleSegmentTest, AddSegmentByteRange) {
                               1001000, 2 * kMBytes);
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -248,7 +248,7 @@ TEST_F(MediaPlaylistMultiSegmentTest, WriteToFile) {
       "#EXT-X-ENDLIST\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -300,7 +300,7 @@ TEST_F(MediaPlaylistMultiSegmentTest, SetTargetDuration) {
       "#EXT-X-ENDLIST\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -326,7 +326,7 @@ TEST_F(MediaPlaylistMultiSegmentTest, WriteToFileWithSegments) {
       "#EXT-X-ENDLIST\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -355,7 +355,7 @@ TEST_F(MediaPlaylistMultiSegmentTest,
       "#EXT-X-ENDLIST\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -387,7 +387,7 @@ TEST_F(MediaPlaylistMultiSegmentTest, WriteToFileWithEncryptionInfo) {
       "#EXT-X-ENDLIST\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -418,7 +418,7 @@ TEST_F(MediaPlaylistMultiSegmentTest, WriteToFileWithEncryptionInfoEmptyIv) {
       "#EXT-X-ENDLIST\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -453,7 +453,7 @@ TEST_F(MediaPlaylistMultiSegmentTest, WriteToFileWithClearLead) {
       "#EXT-X-ENDLIST\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -584,7 +584,7 @@ TEST_F(MediaPlaylistMultiSegmentTest, InitSegment) {
       "#EXT-X-ENDLIST\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -618,7 +618,7 @@ TEST_F(MediaPlaylistMultiSegmentTest, SampleAesCenc) {
       "#EXT-X-ENDLIST\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -658,7 +658,7 @@ TEST_F(MediaPlaylistMultiSegmentTest, MultipleEncryptionInfo) {
       "#EXT-X-ENDLIST\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -678,7 +678,7 @@ TEST_F(MediaPlaylistSingleSegmentTest, StartTimeEmpty) {
   ASSERT_TRUE(media_playlist_->SetMediaInfo(valid_video_media_info_));
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, true));
 
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
@@ -699,7 +699,7 @@ TEST_F(MediaPlaylistSingleSegmentTest, StartTimeZero) {
   ASSERT_TRUE(media_playlist_->SetMediaInfo(valid_video_media_info_));
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, true));
 
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
@@ -720,7 +720,7 @@ TEST_F(MediaPlaylistSingleSegmentTest, StartTimePositive) {
   ASSERT_TRUE(media_playlist_->SetMediaInfo(valid_video_media_info_));
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, true));
 
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
@@ -741,7 +741,7 @@ TEST_F(MediaPlaylistSingleSegmentTest, StartTimeNegative) {
   ASSERT_TRUE(media_playlist_->SetMediaInfo(valid_video_media_info_));
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, true));
 
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
@@ -771,7 +771,7 @@ TEST_F(LiveMediaPlaylistTest, Basic) {
       "file2.ts\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -797,7 +797,7 @@ TEST_F(LiveMediaPlaylistTest, TimeShifted) {
       "file3.ts\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -837,7 +837,7 @@ TEST_F(LiveMediaPlaylistTest, TimeShiftedWithEncryptionInfo) {
       "file3.ts\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -904,7 +904,7 @@ TEST_F(LiveMediaPlaylistTest, TimeShiftedWithEncryptionInfoShifted) {
       "file4.ts\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -934,7 +934,7 @@ TEST_F(EventMediaPlaylistTest, Basic) {
       "file2.ts\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -990,7 +990,7 @@ TEST_F(IFrameMediaPlaylistTest, SingleSegment) {
       "#EXT-X-ENDLIST\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -1031,7 +1031,7 @@ TEST_F(IFrameMediaPlaylistTest, MultiSegment) {
       "#EXT-X-ENDLIST\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -1074,7 +1074,7 @@ TEST_F(IFrameMediaPlaylistTest, MultiSegmentWithPlacementOpportunity) {
       "#EXT-X-ENDLIST\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 

--- a/packager/hls/base/mock_media_playlist.h
+++ b/packager/hls/base/mock_media_playlist.h
@@ -44,7 +44,7 @@ class MockMediaPlaylist : public MediaPlaylist {
                     const std::string& key_format,
                     const std::string& key_format_versions));
   MOCK_METHOD0(AddPlacementOpportunity, void());
-  MOCK_METHOD1(WriteToFile, bool(const std::filesystem::path& file_path));
+  MOCK_METHOD2(WriteToFile, bool(const std::filesystem::path& file_path, const bool endOfStream));
   MOCK_CONST_METHOD0(MaxBitrate, uint64_t());
   MOCK_CONST_METHOD0(AvgBitrate, uint64_t());
   MOCK_CONST_METHOD0(GetLongestSegmentDuration, double());

--- a/packager/hls/base/simple_hls_notifier.cc
+++ b/packager/hls/base/simple_hls_notifier.cc
@@ -249,9 +249,9 @@ bool HandleWidevineKeyFormats(
 }
 
 bool WriteMediaPlaylist(const std::string& output_dir,
-                        MediaPlaylist* playlist) {
+                        MediaPlaylist* playlist, const bool endStream) {
   auto file_path = std::filesystem::u8path(output_dir) / playlist->file_name();
-  if (!playlist->WriteToFile(file_path)) {
+  if (!playlist->WriteToFile(file_path, endStream)) {
     LOG(ERROR) << "Failed to write playlist " << file_path.string();
     return false;
   }
@@ -390,11 +390,11 @@ bool SimpleHlsNotifier::NotifyNewSegment(uint32_t stream_id,
     if (target_duration_updated) {
       for (MediaPlaylist* playlist : media_playlists_) {
         playlist->SetTargetDuration(target_duration_);
-        if (!WriteMediaPlaylist(master_playlist_dir_, playlist))
+        if (!WriteMediaPlaylist(master_playlist_dir_, playlist, endStream))
           return false;
       }
     } else {
-      if (!WriteMediaPlaylist(master_playlist_dir_, media_playlist.get()))
+      if (!WriteMediaPlaylist(master_playlist_dir_, media_playlist.get(), endStream))
         return false;
     }
     if (!master_playlist_->WriteMasterPlaylist(
@@ -524,11 +524,16 @@ bool SimpleHlsNotifier::NotifyEncryptionUpdate(
   return true;
 }
 
+bool SimpleHlsNotifier::NotifyEndOfStream() {
+	endStream = true;
+	return true;
+}
+
 bool SimpleHlsNotifier::Flush() {
   absl::MutexLock lock(&lock_);
   for (MediaPlaylist* playlist : media_playlists_) {
     playlist->SetTargetDuration(target_duration_);
-    if (!WriteMediaPlaylist(master_playlist_dir_, playlist))
+    if (!WriteMediaPlaylist(master_playlist_dir_, playlist, endStream))
       return false;
   }
   if (!master_playlist_->WriteMasterPlaylist(

--- a/packager/hls/base/simple_hls_notifier.h
+++ b/packager/hls/base/simple_hls_notifier.h
@@ -70,6 +70,9 @@ class SimpleHlsNotifier : public HlsNotifier {
       const std::vector<uint8_t>& system_id,
       const std::vector<uint8_t>& iv,
       const std::vector<uint8_t>& protection_system_specific_data) override;
+
+  bool NotifyEndOfStream() override;
+
   bool Flush() override;
   /// }@
 
@@ -86,6 +89,7 @@ class SimpleHlsNotifier : public HlsNotifier {
 
   std::string master_playlist_dir_;
   int32_t target_duration_ = 0;
+  bool endStream = false;
 
   std::unique_ptr<MediaPlaylistFactory> media_playlist_factory_;
   std::unique_ptr<MasterPlaylist> master_playlist_;
@@ -97,7 +101,6 @@ class SimpleHlsNotifier : public HlsNotifier {
   uint32_t sequence_number_ = 0;
 
   absl::Mutex lock_;
-  absl::Time reference_time_ = absl::InfinitePast();
 
   DISALLOW_COPY_AND_ASSIGN(SimpleHlsNotifier);
 };

--- a/packager/hls/base/simple_hls_notifier_unittest.cc
+++ b/packager/hls/base/simple_hls_notifier_unittest.cc
@@ -249,7 +249,7 @@ TEST_F(SimpleHlsNotifierTest, NotifyNewSegment) {
       .Times(1);
   EXPECT_CALL(*mock_media_playlist,
               WriteToFile(Eq(
-                  (std::filesystem::u8path(kAnyOutputDir) / "playlist.m3u8"))))
+                  (std::filesystem::u8path(kAnyOutputDir) / "playlist.m3u8")), Eq(false)))
       .WillOnce(Return(true));
   EXPECT_TRUE(notifier.Flush());
 }
@@ -535,7 +535,7 @@ TEST_P(LiveOrEventSimpleHlsNotifierTest, NotifyNewSegment) {
       .Times(1);
   EXPECT_CALL(*mock_media_playlist,
               WriteToFile(Eq(
-                  (std::filesystem::u8path(kAnyOutputDir) / "playlist.m3u8"))))
+                  (std::filesystem::u8path(kAnyOutputDir) / "playlist.m3u8")), Eq(false)))
       .WillOnce(Return(true));
 
   hls_params_.playlist_type = GetParam();
@@ -603,13 +603,13 @@ TEST_P(LiveOrEventSimpleHlsNotifierTest, NotifyNewSegmentsWithMultipleStreams) {
       .Times(1);
   EXPECT_CALL(*mock_media_playlist1,
               WriteToFile(Eq(
-                  (std::filesystem::u8path(kAnyOutputDir) / "playlist1.m3u8"))))
+                  (std::filesystem::u8path(kAnyOutputDir) / "playlist1.m3u8")), Eq(false)))
       .WillOnce(Return(true));
   EXPECT_CALL(*mock_media_playlist2, SetTargetDuration(kTargetDuration))
       .Times(1);
   EXPECT_CALL(*mock_media_playlist2,
               WriteToFile(Eq(
-                  (std::filesystem::u8path(kAnyOutputDir) / "playlist2.m3u8"))))
+                  (std::filesystem::u8path(kAnyOutputDir) / "playlist2.m3u8")), Eq(false)))
       .WillOnce(Return(true));
   EXPECT_CALL(
       *mock_master_playlist_ptr,
@@ -625,7 +625,7 @@ TEST_P(LiveOrEventSimpleHlsNotifierTest, NotifyNewSegmentsWithMultipleStreams) {
   // Not updating other playlists as target duration does not change.
   EXPECT_CALL(*mock_media_playlist2,
               WriteToFile(Eq(
-                  (std::filesystem::u8path(kAnyOutputDir) / "playlist2.m3u8"))))
+                  (std::filesystem::u8path(kAnyOutputDir) / "playlist2.m3u8")), Eq(false)))
       .WillOnce(Return(true));
   EXPECT_CALL(*mock_master_playlist_ptr, WriteMasterPlaylist(_, _, _))
       .WillOnce(Return(true));

--- a/packager/media/event/hls_notify_muxer_listener.cc
+++ b/packager/media/event/hls_notify_muxer_listener.cc
@@ -169,6 +169,7 @@ void HlsNotifyMuxerListener::OnMediaEnd(const MediaRanges& media_ranges,
   // before all Media Playlists are read. Which could cause problems
   // setting the correct EXT-X-TARGETDURATION.
   if (media_info_->has_segment_template()) {
+	hls_notifier_->NotifyEndOfStream();
     return;
   }
   if (media_ranges.init_range) {
@@ -239,6 +240,8 @@ void HlsNotifyMuxerListener::OnMediaEnd(const MediaRanges& media_ranges,
     }
   }
   event_info_.clear();
+
+  hls_notifier_->NotifyEndOfStream();
 }
 
 void HlsNotifyMuxerListener::OnNewSegment(const std::string& file_name,

--- a/packager/media/event/hls_notify_muxer_listener_unittest.cc
+++ b/packager/media/event/hls_notify_muxer_listener_unittest.cc
@@ -61,6 +61,7 @@ class MockHlsNotifier : public hls::HlsNotifier {
            const std::vector<uint8_t>& system_id,
            const std::vector<uint8_t>& iv,
            const std::vector<uint8_t>& protection_system_specific_data));
+  MOCK_METHOD0(NotifyEndOfStream, bool());
   MOCK_METHOD0(Flush, bool());
 };
 
@@ -375,6 +376,8 @@ TEST_F(HlsNotifyMuxerListenerTest, NoSegmentTemplateOnMediaEnd) {
       mock_notifier_,
       NotifyNewSegment(_, StrEq("filename.mp4"), kSegmentStartTime,
                        kSegmentDuration, kSegmentStartOffset, kSegmentSize));
+  EXPECT_CALL(mock_notifier_, NotifyEndOfStream());
+
   listener_.OnMediaEnd(
       GetMediaRanges(
           {{kSegmentStartOffset, kSegmentStartOffset + kSegmentSize - 1}}),
@@ -406,6 +409,8 @@ TEST_F(HlsNotifyMuxerListenerTest, NoSegmentTemplateOnMediaEndTwice) {
   EXPECT_CALL(mock_notifier_, NotifyNewSegment(_, StrEq("filename1.mp4"),
                                                kSegmentStartTime, _, _, _));
   EXPECT_CALL(mock_notifier_, NotifyCueEvent(_, kCueStartTime));
+
+  EXPECT_CALL(mock_notifier_, NotifyEndOfStream());
   listener_.OnMediaEnd(
       GetMediaRanges(
           {{kSegmentStartOffset, kSegmentStartOffset + kSegmentSize - 1}}),
@@ -419,6 +424,8 @@ TEST_F(HlsNotifyMuxerListenerTest, NoSegmentTemplateOnMediaEndTwice) {
   EXPECT_CALL(mock_notifier_,
               NotifyNewSegment(_, StrEq("filename2.mp4"),
                                kSegmentStartTime + kSegmentDuration, _, _, _));
+
+  EXPECT_CALL(mock_notifier_, NotifyEndOfStream());
   listener_.OnMediaEnd(
       GetMediaRanges(
           {{kSegmentStartOffset, kSegmentStartOffset + kSegmentSize - 1}}),
@@ -446,6 +453,8 @@ TEST_F(HlsNotifyMuxerListenerTest,
       mock_notifier_,
       NotifyNewSegment(_, StrEq("filename.mp4"), kSegmentStartTime,
                        kSegmentDuration, kSegmentStartOffset, kSegmentSize));
+  EXPECT_CALL(mock_notifier_, NotifyEndOfStream());
+
   listener_.OnMediaEnd(
       GetMediaRanges(
           {{kSegmentStartOffset, kSegmentStartOffset + kSegmentSize - 1},
@@ -516,6 +525,7 @@ TEST_P(HlsNotifyMuxerListenerKeyFrameTest, NoSegmentTemplate) {
       mock_notifier_,
       NotifyNewSegment(_, StrEq("filename.mp4"), kSegmentStartTime,
                        kSegmentDuration, kSegmentStartOffset, kSegmentSize));
+  EXPECT_CALL(mock_notifier_, NotifyEndOfStream());
 
   MuxerListener::MediaRanges ranges;
   ranges.subsegment_ranges.push_back(

--- a/packager/media/event/mpd_notify_muxer_listener.cc
+++ b/packager/media/event/mpd_notify_muxer_listener.cc
@@ -151,10 +151,15 @@ void MpdNotifyMuxerListener::OnMediaEnd(const MediaRanges& media_ranges,
                                         float duration_seconds) {
   if (mpd_notifier_->dash_profile() == DashProfile::kLive) {
     DCHECK(event_info_.empty());
-    // TODO(kqyang): Set mpd duration to |duration_seconds|, which is more
-    // accurate than the duration coded in the original media header.
+
     if (mpd_notifier_->mpd_type() == MpdType::kStatic)
       mpd_notifier_->Flush();
+    else {
+      // Set mpd duration to |duration_seconds|, which is more
+      // accurate than the duration coded in the original media header.
+	  media_info_->set_media_duration_seconds(duration_seconds);
+      mpd_notifier_->NotifyEndOfStream();
+    }
     return;
   }
 

--- a/packager/mpd/base/mock_mpd_notifier.h
+++ b/packager/mpd/base/mock_mpd_notifier.h
@@ -45,6 +45,7 @@ class MockMpdNotifier : public MpdNotifier {
                     const std::vector<uint8_t>& new_pssh));
   MOCK_METHOD2(NotifyMediaInfoUpdate,
                bool(uint32_t container_id, const MediaInfo& media_info));
+  MOCK_METHOD0(NotifyEndOfStream, bool());
   MOCK_METHOD0(Flush, bool());
 };
 

--- a/packager/mpd/base/mpd_builder.cc
+++ b/packager/mpd/base/mpd_builder.cc
@@ -330,6 +330,11 @@ float MpdBuilder::GetStaticMpdDuration() {
   return total_duration;
 }
 
+void MpdBuilder::FinalizeDynamicMpd() {
+	mpd_options_.dash_profile = DashProfile::kOnDemand;
+	mpd_options_.mpd_type = MpdType::kStatic;
+}
+
 bool MpdBuilder::GetEarliestTimestamp(double* timestamp_seconds) {
   DCHECK(timestamp_seconds);
   DCHECK(!periods_.empty());

--- a/packager/mpd/base/mpd_builder.h
+++ b/packager/mpd/base/mpd_builder.h
@@ -54,6 +54,10 @@ class MpdBuilder {
   ///         return a new Period.
   virtual Period* GetOrCreatePeriod(double start_time_in_seconds);
 
+  /// Convert the stream from a dynamic Live/EVENT to a static VOD stream.
+  /// This is a no-op for VOD streams.
+  void FinalizeDynamicMpd();
+
   /// Writes the MPD to the given string.
   /// @param[out] output is an output string where the MPD gets written.
   /// @return true on success, false otherwise.

--- a/packager/mpd/base/mpd_notifier.h
+++ b/packager/mpd/base/mpd_notifier.h
@@ -143,6 +143,10 @@ class MpdNotifier {
   virtual bool NotifyMediaInfoUpdate(uint32_t container_id,
                                      const MediaInfo& media_info) = 0;
 
+  /// Convert the stream from a dynamic Live/EVENT to a static VOD stream.
+  /// This is a no-op for VOD streams.
+  virtual bool NotifyEndOfStream() = 0;
+
   /// Call this method to force a flush. Implementations might not write out
   /// the MPD to a stream (file, stdout, etc.) when the MPD is updated, this
   /// forces a flush.
@@ -156,6 +160,8 @@ class MpdNotifier {
 
   /// @return The mpd type for this object.
   MpdType mpd_type() const { return mpd_options_.mpd_type; }
+
+  void set_duration(float duration);
 
   /// @return The value of dash_force_segment_list flag
   bool use_segment_list() const {

--- a/packager/mpd/base/simple_mpd_notifier.cc
+++ b/packager/mpd/base/simple_mpd_notifier.cc
@@ -202,6 +202,12 @@ bool SimpleMpdNotifier::NotifyEncryptionUpdate(
   return true;
 }
 
+bool SimpleMpdNotifier::NotifyEndOfStream() {
+  absl::MutexLock lock(&lock_);
+  mpd_builder_->FinalizeDynamicMpd();
+  return true;
+}
+
 bool SimpleMpdNotifier::NotifyMediaInfoUpdate(uint32_t container_id,
                                               const MediaInfo& media_info) {
   absl::MutexLock lock(&lock_);

--- a/packager/mpd/base/simple_mpd_notifier.h
+++ b/packager/mpd/base/simple_mpd_notifier.h
@@ -57,6 +57,9 @@ class SimpleMpdNotifier : public MpdNotifier {
                               const std::vector<uint8_t>& new_pssh) override;
   bool NotifyMediaInfoUpdate(uint32_t container_id,
                              const MediaInfo& media_info) override;
+
+  bool NotifyEndOfStream() override;
+
   bool Flush() override;
   /// @}
 


### PR DESCRIPTION
Implement the MPEG DASH/HLS specifications to switch event/live streams to VOD when the streams end.

This change implements the DASH standard by:

1. Change MPD@type to "static"
2. Set MPD@mediaPresentationDuration to the media duration
3. Removing "dynamic" specific attributes in element, e.g. availabilityStartTime, minimumUpdatePeriod, timeShiftBufferDepth etc.
4. Set SegmentTemplate@presentationTimeOffset in Representations

This change implements the HLS standard by:

1. Switch the PLAYLIST-TYPE to VOD at the conclusion of a LIVE stream
2. Append an EXT-X-ENDLIST tag at the end of the stream