### PR TITLE
feat: Add signaling for CEA-608/708 captions

### DIFF
--- a/include/packager/hls_params.h
+++ b/include/packager/hls_params.h
@@ -89,10 +89,8 @@ struct HlsParams {
   /// Add EXT-X-PROGRAM-DATE-TIME tag to the playlist. The date time is derived
   /// from the current wall clock.
   bool add_program_date_time = false;
-  /// CEA-608 captions.
-  std::vector<CeaCaption> cea608;
-  /// CEA-708 captions.
-  std::vector<CeaCaption> cea708;
+  /// CEA-608 / CEA-708 captions.
+  std::vector<CeaCaption> closed_captions;
 };
 
 }  // namespace shaka

--- a/include/packager/hls_params.h
+++ b/include/packager/hls_params.h
@@ -21,6 +21,20 @@ enum class HlsPlaylistType {
   kLive,
 };
 
+// CEA caption description.
+struct CeaCaption {
+  // The display name of the caption.
+  std::string name;
+  // The language of the caption.
+  std::string language;
+  // The channel of the caption, e.g. "CC1", "SERVICE2".
+  std::string channel;
+  // True if this is the default caption.
+  bool is_default = false;
+  // True if this caption should be autoselected.
+  bool autoselect = true;
+};
+
 /// HLS related parameters.
 struct HlsParams {
   /// HLS playlist type. See HLS specification for details.
@@ -75,6 +89,10 @@ struct HlsParams {
   /// Add EXT-X-PROGRAM-DATE-TIME tag to the playlist. The date time is derived
   /// from the current wall clock.
   bool add_program_date_time = false;
+  /// CEA-608 captions.
+  std::vector<CeaCaption> cea608;
+  /// CEA-708 captions.
+  std::vector<CeaCaption> cea708;
 };
 
 }  // namespace shaka

--- a/include/packager/hls_params.h
+++ b/include/packager/hls_params.h
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace shaka {
 

--- a/packager/app/manifest_flags.cc
+++ b/packager/app/manifest_flags.cc
@@ -43,21 +43,21 @@ ABSL_FLAG(bool,
           "True forces the muxer to order streams in the order given "
           "on the command-line. False uses the previous unordered behavior.");
 ABSL_FLAG(
-          std::string,
-          cea608,
-          "",
-          "Specifies a CEA-608 closed caption channel. Can be specified multiple "
-          "times to specify multiple channels. The value is a comma separated "
-          "list of key-value pairs. Supported keys: channel(CC1|CC2|CC3|CC4), "
-          "name, lang, default(yes|no), autoselect(yes|no). Example: "
-          "--cea608 channel=CC1,name=English,lang=eng");
+    std::string,
+    cea608,
+    "",
+    "Specifies a CEA-608 closed caption channel. Can be specified multiple "
+    "times to specify multiple channels. The value is a comma separated "
+    "list of key-value pairs. Supported keys: channel(CC1|CC2|CC3|CC4), "
+    "name, lang, default(yes|no), autoselect(yes|no). Example: "
+    "--cea608 channel=CC1,name=English,lang=eng");
 ABSL_FLAG(
-          std::string,
-          cea708,
-          "",
-          "Specifies a CEA-708 closed caption channel. Can be specified multiple "
-          "times to specify multiple channels. The value is a comma separated "
-          "list of key-value pairs. Supported keys: "
-          "channel(SERVICE1..SERVICE63), name, lang, default(yes|no), "
-          "autoselect(yes|no). Example: --cea708 "
-          "channel=SERVICE1,name=English,lang=eng");
+    std::string,
+    cea708,
+    "",
+    "Specifies a CEA-708 closed caption channel. Can be specified multiple "
+    "times to specify multiple channels. The value is a comma separated "
+    "list of key-value pairs. Supported keys: "
+    "channel(SERVICE1..SERVICE63), name, lang, default(yes|no), "
+    "autoselect(yes|no). Example: --cea708 "
+    "channel=SERVICE1,name=English,lang=eng");

--- a/packager/app/manifest_flags.cc
+++ b/packager/app/manifest_flags.cc
@@ -44,25 +44,12 @@ ABSL_FLAG(bool,
           "on the command-line. False uses the previous unordered behavior.");
 ABSL_FLAG(
     std::string,
-    cea608,
+    closed_captions,
     "",
     "Specifies one or more CEA-608 closed caption channels. Multiple channels "
     "can be provided in a single flag, separated by semicolons (;). Each "
     "channel is defined as a comma-separated list of key-value pairs. "
-    "Supported keys: channel(CC1|CC2|CC3|CC4), name, lang, default(yes|no), "
+    "Supported keys: channel(CC1..CC4, SERVICE1..SERVICE63), name, lang, default(yes|no), "
     "autoselect(yes|no). Example: "
-    "--cea608 "
+    "--closed_captions "
     "channel=CC1,name=English,lang=eng;channel=CC2,name=French,lang=fra");
-ABSL_FLAG(
-    std::string,
-    cea708,
-    "",
-    "Specifies one or more CEA-708 closed caption channels. Multiple channels "
-    "can be provided in a single flag, separated by semicolons (;). Each "
-    "channel is defined as a comma-separated list of key-value pairs. "
-    "Supported keys: channel(SERVICE1..SERVICE63), name, lang, "
-    "default(yes|no), "
-    "autoselect(yes|no). Example: "
-    "--cea708 "
-    "channel=SERVICE1,name=English,lang=eng;channel=SERVICE2,name=French,lang="
-    "fra");

--- a/packager/app/manifest_flags.cc
+++ b/packager/app/manifest_flags.cc
@@ -42,3 +42,22 @@ ABSL_FLAG(bool,
           true,
           "True forces the muxer to order streams in the order given "
           "on the command-line. False uses the previous unordered behavior.");
+ABSL_FLAG(
+          std::string,
+          cea608,
+          "",
+          "Specifies a CEA-608 closed caption channel. Can be specified multiple "
+          "times to specify multiple channels. The value is a comma separated "
+          "list of key-value pairs. Supported keys: channel(CC1|CC2|CC3|CC4), "
+          "name, lang, default(yes|no), autoselect(yes|no). Example: "
+          "--cea608 channel=CC1,name=English,lang=eng");
+ABSL_FLAG(
+          std::string,
+          cea708,
+          "",
+          "Specifies a CEA-708 closed caption channel. Can be specified multiple "
+          "times to specify multiple channels. The value is a comma separated "
+          "list of key-value pairs. Supported keys: "
+          "channel(SERVICE1..SERVICE63), name, lang, default(yes|no), "
+          "autoselect(yes|no). Example: --cea708 "
+          "channel=SERVICE1,name=English,lang=eng");

--- a/packager/app/manifest_flags.cc
+++ b/packager/app/manifest_flags.cc
@@ -46,18 +46,19 @@ ABSL_FLAG(
     std::string,
     cea608,
     "",
-    "Specifies a CEA-608 closed caption channel. Can be specified multiple "
-    "times to specify multiple channels. The value is a comma separated "
-    "list of key-value pairs. Supported keys: channel(CC1|CC2|CC3|CC4), "
-    "name, lang, default(yes|no), autoselect(yes|no). Example: "
-    "--cea608 channel=CC1,name=English,lang=eng");
+    "Specifies one or more CEA-608 closed caption channels. Multiple channels "
+    "can be provided in a single flag, separated by semicolons (;). Each "
+    "channel is defined as a comma-separated list of key-value pairs. "
+    "Supported keys: channel(CC1|CC2|CC3|CC4), name, lang, default(yes|no), "
+    "autoselect(yes|no). Example: "
+    "--cea608 channel=CC1,name=English,lang=eng;channel=CC2,name=French,lang=fra");
 ABSL_FLAG(
     std::string,
     cea708,
     "",
-    "Specifies a CEA-708 closed caption channel. Can be specified multiple "
-    "times to specify multiple channels. The value is a comma separated "
-    "list of key-value pairs. Supported keys: "
-    "channel(SERVICE1..SERVICE63), name, lang, default(yes|no), "
-    "autoselect(yes|no). Example: --cea708 "
-    "channel=SERVICE1,name=English,lang=eng");
+    "Specifies one or more CEA-708 closed caption channels. Multiple channels "
+    "can be provided in a single flag, separated by semicolons (;). Each "
+    "channel is defined as a comma-separated list of key-value pairs. "
+    "Supported keys: channel(SERVICE1..SERVICE63), name, lang, default(yes|no), "
+    "autoselect(yes|no). Example: "
+    "--cea708 channel=SERVICE1,name=English,lang=eng;channel=SERVICE2,name=French,lang=fra");

--- a/packager/app/manifest_flags.cc
+++ b/packager/app/manifest_flags.cc
@@ -49,7 +49,8 @@ ABSL_FLAG(
     "Specifies one or more CEA-608 closed caption channels. Multiple channels "
     "can be provided in a single flag, separated by semicolons (;). Each "
     "channel is defined as a comma-separated list of key-value pairs. "
-    "Supported keys: channel(CC1..CC4, SERVICE1..SERVICE63), name, lang, default(yes|no), "
+    "Supported keys: channel(CC1..CC4, SERVICE1..SERVICE63), name, lang, "
+    "default(yes|no), "
     "autoselect(yes|no). Example: "
     "--closed_captions "
     "channel=CC1,name=English,lang=eng;channel=CC2,name=French,lang=fra");

--- a/packager/app/manifest_flags.cc
+++ b/packager/app/manifest_flags.cc
@@ -51,7 +51,8 @@ ABSL_FLAG(
     "channel is defined as a comma-separated list of key-value pairs. "
     "Supported keys: channel(CC1|CC2|CC3|CC4), name, lang, default(yes|no), "
     "autoselect(yes|no). Example: "
-    "--cea608 channel=CC1,name=English,lang=eng;channel=CC2,name=French,lang=fra");
+    "--cea608 "
+    "channel=CC1,name=English,lang=eng;channel=CC2,name=French,lang=fra");
 ABSL_FLAG(
     std::string,
     cea708,
@@ -59,6 +60,9 @@ ABSL_FLAG(
     "Specifies one or more CEA-708 closed caption channels. Multiple channels "
     "can be provided in a single flag, separated by semicolons (;). Each "
     "channel is defined as a comma-separated list of key-value pairs. "
-    "Supported keys: channel(SERVICE1..SERVICE63), name, lang, default(yes|no), "
+    "Supported keys: channel(SERVICE1..SERVICE63), name, lang, "
+    "default(yes|no), "
     "autoselect(yes|no). Example: "
-    "--cea708 channel=SERVICE1,name=English,lang=eng;channel=SERVICE2,name=French,lang=fra");
+    "--cea708 "
+    "channel=SERVICE1,name=English,lang=eng;channel=SERVICE2,name=French,lang="
+    "fra");

--- a/packager/app/manifest_flags.h
+++ b/packager/app/manifest_flags.h
@@ -19,7 +19,6 @@ ABSL_DECLARE_FLAG(uint64_t, preserved_segments_outside_live_window);
 ABSL_DECLARE_FLAG(std::string, default_language);
 ABSL_DECLARE_FLAG(std::string, default_text_language);
 ABSL_DECLARE_FLAG(bool, force_cl_index);
-ABSL_DECLARE_FLAG(std::string, cea608);
-ABSL_DECLARE_FLAG(std::string, cea708);
+ABSL_DECLARE_FLAG(std::string, closed_captions);
 
 #endif  // PACKAGER_APP_MANIFEST_FLAGS_H_

--- a/packager/app/manifest_flags.h
+++ b/packager/app/manifest_flags.h
@@ -19,5 +19,7 @@ ABSL_DECLARE_FLAG(uint64_t, preserved_segments_outside_live_window);
 ABSL_DECLARE_FLAG(std::string, default_language);
 ABSL_DECLARE_FLAG(std::string, default_text_language);
 ABSL_DECLARE_FLAG(bool, force_cl_index);
+ABSL_DECLARE_FLAG(std::string, cea608);
+ABSL_DECLARE_FLAG(std::string, cea708);
 
 #endif  // PACKAGER_APP_MANIFEST_FLAGS_H_

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -336,7 +336,7 @@ bool ParseProtectionSystems(const std::string& protection_systems_str,
   return true;
 }
 
-bool ParseCeaCaptions(const std::string& captions_str,
+bool ParseClosedCaptions(const std::string& captions_str,
                       std::vector<CeaCaption>* captions) {
   std::vector<std::string> captions_list =
       SplitAndTrimSkipEmpty(captions_str, ';');
@@ -557,8 +557,6 @@ std::optional<PackagingParams> GetPackagingParams() {
   mpd_params.include_mspr_pro =
       absl::GetFlag(FLAGS_include_mspr_pro_for_playready);
   mpd_params.low_latency_dash_mode = absl::GetFlag(FLAGS_low_latency_dash_mode);
-  mpd_params.cea608 = absl::GetFlag(FLAGS_cea608);
-  mpd_params.cea708 = absl::GetFlag(FLAGS_cea708);
 
   HlsParams& hls_params = packaging_params.hls_params;
   if (!GetHlsPlaylistType(absl::GetFlag(FLAGS_hls_playlist_type),
@@ -581,12 +579,8 @@ std::optional<PackagingParams> GetPackagingParams() {
   hls_params.create_session_keys = absl::GetFlag(FLAGS_create_session_keys);
   hls_params.add_program_date_time = absl::GetFlag(FLAGS_add_program_date_time);
 
-  if (!ParseCeaCaptions(absl::GetFlag(FLAGS_cea608), &hls_params.cea608)) {
-    LOG(ERROR) << "Failed to parse --cea608 " << absl::GetFlag(FLAGS_cea608);
-    return std::nullopt;
-  }
-  if (!ParseCeaCaptions(absl::GetFlag(FLAGS_cea708), &hls_params.cea708)) {
-    LOG(ERROR) << "Failed to parse --cea708 " << absl::GetFlag(FLAGS_cea708);
+  if (!ParseClosedCaptions(absl::GetFlag(FLAGS_closed_captions), &hls_params.closed_captions)) {
+    LOG(ERROR) << "Failed to parse --closed_captions " << absl::GetFlag(FLAGS_closed_captions);
     return std::nullopt;
   }
 

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -337,7 +337,7 @@ bool ParseProtectionSystems(const std::string& protection_systems_str,
 }
 
 bool ParseClosedCaptions(const std::string& captions_str,
-                      std::vector<CeaCaption>* captions) {
+                         std::vector<CeaCaption>* captions) {
   std::vector<std::string> captions_list =
       SplitAndTrimSkipEmpty(captions_str, ';');
   for (const std::string& caption_str : captions_list) {
@@ -579,8 +579,10 @@ std::optional<PackagingParams> GetPackagingParams() {
   hls_params.create_session_keys = absl::GetFlag(FLAGS_create_session_keys);
   hls_params.add_program_date_time = absl::GetFlag(FLAGS_add_program_date_time);
 
-  if (!ParseClosedCaptions(absl::GetFlag(FLAGS_closed_captions), &hls_params.closed_captions)) {
-    LOG(ERROR) << "Failed to parse --closed_captions " << absl::GetFlag(FLAGS_closed_captions);
+  if (!ParseClosedCaptions(absl::GetFlag(FLAGS_closed_captions),
+                           &hls_params.closed_captions)) {
+    LOG(ERROR) << "Failed to parse --closed_captions "
+               << absl::GetFlag(FLAGS_closed_captions);
     return std::nullopt;
   }
 

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -352,9 +352,9 @@ bool ParseClosedCaptions(const std::string& captions_str,
       } else if (part.first == "name") {
         caption.name = part.second;
       } else if (part.first == "default") {
-        caption.is_default = (part.second == "true");
+        caption.is_default = (part.second == "yes");
       } else if (part.first == "autoselect") {
-        caption.autoselect = (part.second == "true");
+        caption.autoselect = (part.second == "yes");
       }
     }
     if (caption.channel.empty()) {

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -679,7 +679,6 @@ int PackagerMain(int argc, char** argv) {
   return kSuccess;
 }
 
-
 }  // namespace
 }  // namespace shaka
 

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -6,6 +6,7 @@
 
 #include <iostream>
 #include <optional>
+#include <vector>
 
 #if defined(OS_WIN)
 #include <codecvt>

--- a/packager/hls/base/master_playlist.cc
+++ b/packager/hls/base/master_playlist.cc
@@ -457,6 +457,8 @@ void BuildCeaMediaTag(const CeaCaption& caption, std::string* out) {
     tag.AddString("DEFAULT", "NO");
   if (caption.autoselect)
     tag.AddString("AUTOSELECT", "YES");
+  else
+    tag.AddString("AUTOSELECT", "NO");
   tag.AddQuotedString("INSTREAM-ID", caption.channel);
   out->append("\n");
 }

--- a/packager/hls/base/master_playlist.cc
+++ b/packager/hls/base/master_playlist.cc
@@ -170,7 +170,7 @@ std::list<Variant> BuildVariants(
     const std::map<std::string, std::list<const MediaPlaylist*>>& audio_groups,
     const std::map<std::string, std::list<const MediaPlaylist*>>&
         subtitle_groups,
-        const bool have_instream_closed_caption) {
+    const bool have_instream_closed_caption) {
   std::list<Variant> audio_variants = AudioGroupsToVariants(audio_groups);
   std::list<Variant> subtitle_variants =
       SubtitleGroupsToVariants(subtitle_groups);
@@ -540,8 +540,9 @@ void AppendPlaylists(const std::string& default_audio_language,
     }
   }
 
-  std::list<Variant> variants = BuildVariants(
-      audio_playlist_groups, subtitle_playlist_groups, !closed_captions.empty());
+  std::list<Variant> variants =
+      BuildVariants(audio_playlist_groups, subtitle_playlist_groups,
+                    !closed_captions.empty());
   for (const auto& variant : variants) {
     if (video_playlists.empty())
       break;
@@ -622,7 +623,7 @@ bool MasterPlaylist::WriteMasterPlaylist(
   }
 
   AppendPlaylists(default_audio_language_, default_text_language_,
-    closed_captions_, base_url, playlists, &content);
+                  closed_captions_, base_url, playlists, &content);
 
   // Skip if the playlist is already written.
   if (content == written_playlist_)

--- a/packager/hls/base/master_playlist.cc
+++ b/packager/hls/base/master_playlist.cc
@@ -170,7 +170,7 @@ std::list<Variant> BuildVariants(
     const std::map<std::string, std::list<const MediaPlaylist*>>& audio_groups,
     const std::map<std::string, std::list<const MediaPlaylist*>>&
         subtitle_groups,
-        const std::list<std::string>& cea_group_ids) {
+    const std::list<std::string>& cea_group_ids) {
   std::list<Variant> audio_variants = AudioGroupsToVariants(audio_groups);
   std::list<Variant> subtitle_variants =
       SubtitleGroupsToVariants(subtitle_groups);
@@ -279,11 +279,9 @@ void BuildStreamInfTag(const MediaPlaylist& playlist,
   }
 
   if (variant.closed_captions_group_id) {
-    tag.AddQuotedString("CLOSED-CAPTIONS",
-                        *variant.closed_captions_group_id);
-  }
-  else {
-      tag.AddString("CLOSED-CAPTIONS", "NONE");
+    tag.AddQuotedString("CLOSED-CAPTIONS", *variant.closed_captions_group_id);
+  } else {
+    tag.AddString("CLOSED-CAPTIONS", "NONE");
   }
 
   if (playlist.stream_type() ==
@@ -640,7 +638,7 @@ bool MasterPlaylist::WriteMasterPlaylist(
   }
 
   AppendPlaylists(default_audio_language_, default_text_language_, cea608_,
-                    cea708_, base_url, playlists, &content);
+                  cea708_, base_url, playlists, &content);
 
   // Skip if the playlist is already written.
   if (content == written_playlist_)

--- a/packager/hls/base/master_playlist.cc
+++ b/packager/hls/base/master_playlist.cc
@@ -9,6 +9,8 @@
 #include <algorithm>  // std::max
 #include <cstdint>
 #include <filesystem>
+#include <set>
+#include <vector>
 
 #include <absl/log/check.h>
 #include <absl/log/log.h>

--- a/packager/hls/base/master_playlist.h
+++ b/packager/hls/base/master_playlist.h
@@ -16,6 +16,14 @@ namespace hls {
 
 class MediaPlaylist;
 
+struct CeaCaption {
+  std::string name;
+  std::string language;
+  std::string channel;
+  bool is_default = false;
+  bool autoselect = true;
+};
+
 /// Class to generate HLS Master Playlist.
 /// Methods are virtual for mocking.
 class MasterPlaylist {
@@ -28,6 +36,8 @@ class MasterPlaylist {
   MasterPlaylist(const std::filesystem::path& file_name,
                  const std::string& default_audio_language,
                  const std::string& default_text_language,
+                 const std::vector<CeaCaption>& cea608,
+                 const std::vector<CeaCaption>& cea708,
                  const bool is_independent_segments,
                  const bool create_session_keys = false);
   virtual ~MasterPlaylist();
@@ -53,6 +63,8 @@ class MasterPlaylist {
   const std::filesystem::path file_name_;
   const std::string default_audio_language_;
   const std::string default_text_language_;
+  const std::vector<CeaCaption> cea608_;
+  const std::vector<CeaCaption> cea708_;
   bool is_independent_segments_;
   bool create_session_keys_;
 };

--- a/packager/hls/base/master_playlist.h
+++ b/packager/hls/base/master_playlist.h
@@ -36,8 +36,7 @@ class MasterPlaylist {
   MasterPlaylist(const std::filesystem::path& file_name,
                  const std::string& default_audio_language,
                  const std::string& default_text_language,
-                 const std::vector<CeaCaption>& cea608,
-                 const std::vector<CeaCaption>& cea708,
+                 const std::vector<CeaCaption>& closed_captions,
                  const bool is_independent_segments,
                  const bool create_session_keys = false);
   virtual ~MasterPlaylist();
@@ -63,8 +62,7 @@ class MasterPlaylist {
   const std::filesystem::path file_name_;
   const std::string default_audio_language_;
   const std::string default_text_language_;
-  const std::vector<CeaCaption> cea608_;
-  const std::vector<CeaCaption> cea708_;
+  const std::vector<CeaCaption> closed_captions_;
   bool is_independent_segments_;
   bool create_session_keys_;
 };

--- a/packager/hls/base/master_playlist.h
+++ b/packager/hls/base/master_playlist.h
@@ -10,6 +10,7 @@
 #include <filesystem>
 #include <list>
 #include <string>
+#include <vector>
 
 namespace shaka {
 namespace hls {

--- a/packager/hls/base/master_playlist_unittest.cc
+++ b/packager/hls/base/master_playlist_unittest.cc
@@ -1094,9 +1094,6 @@ TEST_F(MasterPlaylistTest, WriteMasterPlaylistWithClosedCaptions) {
       "\n"
       "#EXT-X-STREAM-INF:BANDWIDTH=435889,AVERAGE-BANDWIDTH=235889,"
       "CODECS=\"avc1\",RESOLUTION=800x600,CLOSED-CAPTIONS=\"CC\"\n"
-      "http://myplaylistdomain.com/media1.m3u8\n\n"
-      "#EXT-X-STREAM-INF:BANDWIDTH=435889,AVERAGE-BANDWIDTH=235889,"
-      "CODECS=\"avc1\",RESOLUTION=800x600,CLOSED-CAPTIONS=\"CC\"\n"
       "http://myplaylistdomain.com/media1.m3u8\n";
 
   ASSERT_EQ(expected, actual);

--- a/packager/hls/base/master_playlist_unittest.cc
+++ b/packager/hls/base/master_playlist_unittest.cc
@@ -145,7 +145,6 @@ class MasterPlaylistTest : public ::testing::Test {
                                             kDefaultAudioLanguage,
                                             kDefaultTextLanguage,
                                             {},
-                                            {},
                                             !kIsIndependentSegments,
                                             kCreateSessionKeys)),
         test_output_dir_("memory://test_dir"),
@@ -193,7 +192,7 @@ TEST_F(MasterPlaylistTest,
 
   master_playlist_.reset(new MasterPlaylist(
       kDefaultMasterPlaylistName, kDefaultAudioLanguage, kDefaultTextLanguage,
-      {}, {}, kIsIndependentSegments, false));
+{}, kIsIndependentSegments, false));
 
   std::unique_ptr<MockMediaPlaylist> mock_playlist =
       CreateVideoPlaylist("media1.m3u8", "avc1", kMaxBitrate, kAvgBitrate);
@@ -1062,16 +1061,16 @@ TEST_F(MasterPlaylistTest, WriteMasterPlaylistAudioOnlyAC4CBI) {
   ASSERT_EQ(expected, actual);
 }
 
-TEST_F(MasterPlaylistTest, WriteMasterPlaylistWithCea608) {
+TEST_F(MasterPlaylistTest, WriteMasterPlaylistWithClosedCaptions) {
   const uint64_t kMaxBitrate = 435889;
   const uint64_t kAvgBitrate = 235889;
 
-  std::vector<CeaCaption> cea608;
-  cea608.push_back({"fr", "fre", "CC1", true, true});
-  cea608.push_back({"en", "eng", "CC2", false, true});
+  std::vector<CeaCaption> closedCaptions;
+  closedCaptions.push_back({"fr", "fre", "CC1", true, true});
+  closedCaptions.push_back({"en", "eng", "CC2", false, true});
   master_playlist_.reset(new MasterPlaylist(
       kDefaultMasterPlaylistName, kDefaultAudioLanguage, kDefaultTextLanguage,
-      cea608, {}, !kIsIndependentSegments, false));
+      closedCaptions, !kIsIndependentSegments, false));
 
   std::unique_ptr<MockMediaPlaylist> mock_playlist =
       CreateVideoPlaylist("media1.m3u8", "avc1", kMaxBitrate, kAvgBitrate);
@@ -1088,16 +1087,16 @@ TEST_F(MasterPlaylistTest, WriteMasterPlaylistWithCea608) {
       "## Generated with https://github.com/shaka-project/shaka-packager "
       "version test\n"
       "\n"
-      "#EXT-X-MEDIA:TYPE=CLOSED-CAPTIONS,GROUP-ID=\"CC1\",NAME=\"fr\","
+      "#EXT-X-MEDIA:TYPE=CLOSED-CAPTIONS,GROUP-ID=\"CC\",NAME=\"fr\","
       "LANGUAGE=\"fre\",DEFAULT=YES,AUTOSELECT=YES,INSTREAM-ID=\"CC1\"\n"
-      "#EXT-X-MEDIA:TYPE=CLOSED-CAPTIONS,GROUP-ID=\"CC2\",NAME=\"en\","
+      "#EXT-X-MEDIA:TYPE=CLOSED-CAPTIONS,GROUP-ID=\"CC\",NAME=\"en\","
       "LANGUAGE=\"eng\",DEFAULT=NO,AUTOSELECT=YES,INSTREAM-ID=\"CC2\"\n"
       "\n"
       "#EXT-X-STREAM-INF:BANDWIDTH=435889,AVERAGE-BANDWIDTH=235889,"
-      "CODECS=\"avc1\",RESOLUTION=800x600,CLOSED-CAPTIONS=\"CC1\"\n"
+      "CODECS=\"avc1\",RESOLUTION=800x600,CLOSED-CAPTIONS=\"CC\"\n"
       "http://myplaylistdomain.com/media1.m3u8\n\n"
       "#EXT-X-STREAM-INF:BANDWIDTH=435889,AVERAGE-BANDWIDTH=235889,"
-      "CODECS=\"avc1\",RESOLUTION=800x600,CLOSED-CAPTIONS=\"CC2\"\n"
+      "CODECS=\"avc1\",RESOLUTION=800x600,CLOSED-CAPTIONS=\"CC\"\n"
       "http://myplaylistdomain.com/media1.m3u8\n";
 
   ASSERT_EQ(expected, actual);

--- a/packager/hls/base/master_playlist_unittest.cc
+++ b/packager/hls/base/master_playlist_unittest.cc
@@ -192,7 +192,7 @@ TEST_F(MasterPlaylistTest,
 
   master_playlist_.reset(new MasterPlaylist(
       kDefaultMasterPlaylistName, kDefaultAudioLanguage, kDefaultTextLanguage,
-{}, kIsIndependentSegments, false));
+      {}, kIsIndependentSegments, false));
 
   std::unique_ptr<MockMediaPlaylist> mock_playlist =
       CreateVideoPlaylist("media1.m3u8", "avc1", kMaxBitrate, kAvgBitrate);

--- a/packager/hls/base/master_playlist_unittest.cc
+++ b/packager/hls/base/master_playlist_unittest.cc
@@ -144,8 +144,8 @@ class MasterPlaylistTest : public ::testing::Test {
       : master_playlist_(new MasterPlaylist(kDefaultMasterPlaylistName,
                                             kDefaultAudioLanguage,
                                             kDefaultTextLanguage,
-                                  {},
-                                  {},
+                                            {},
+                                            {},
                                             !kIsIndependentSegments,
                                             kCreateSessionKeys)),
         test_output_dir_("memory://test_dir"),
@@ -191,13 +191,9 @@ TEST_F(MasterPlaylistTest,
   const uint64_t kMaxBitrate = 435889;
   const uint64_t kAvgBitrate = 235889;
 
-  master_playlist_.reset(new MasterPlaylist(kDefaultMasterPlaylistName,
-                                              kDefaultAudioLanguage,
-                                              kDefaultTextLanguage,
-                                              {},
-                                              {},
-                                              kIsIndependentSegments,
-                                              false));
+  master_playlist_.reset(new MasterPlaylist(
+      kDefaultMasterPlaylistName, kDefaultAudioLanguage, kDefaultTextLanguage,
+      {}, {}, kIsIndependentSegments, false));
 
   std::unique_ptr<MockMediaPlaylist> mock_playlist =
       CreateVideoPlaylist("media1.m3u8", "avc1", kMaxBitrate, kAvgBitrate);
@@ -1073,20 +1069,16 @@ TEST_F(MasterPlaylistTest, WriteMasterPlaylistWithCea608) {
   std::vector<CeaCaption> cea608;
   cea608.push_back({"fr", "fre", "CC1", true, true});
   cea608.push_back({"en", "eng", "CC2", false, true});
-  master_playlist_.reset(new MasterPlaylist(kDefaultMasterPlaylistName,
-                                            kDefaultAudioLanguage,
-                                            kDefaultTextLanguage,
-                                            cea608,
-                                            {},
-                                            !kIsIndependentSegments,
-                                            false));
+  master_playlist_.reset(new MasterPlaylist(
+      kDefaultMasterPlaylistName, kDefaultAudioLanguage, kDefaultTextLanguage,
+      cea608, {}, !kIsIndependentSegments, false));
 
   std::unique_ptr<MockMediaPlaylist> mock_playlist =
       CreateVideoPlaylist("media1.m3u8", "avc1", kMaxBitrate, kAvgBitrate);
 
   const char kBaseUrl[] = "http://myplaylistdomain.com/";
   EXPECT_TRUE(master_playlist_->WriteMasterPlaylist(kBaseUrl, test_output_dir_,
-                                                   {mock_playlist.get()}));
+                                                    {mock_playlist.get()}));
   std::string actual;
   ASSERT_TRUE(
       File::ReadFileToString(master_playlist_path_.string().c_str(), &actual));

--- a/packager/hls/base/master_playlist_unittest.cc
+++ b/packager/hls/base/master_playlist_unittest.cc
@@ -144,6 +144,8 @@ class MasterPlaylistTest : public ::testing::Test {
       : master_playlist_(new MasterPlaylist(kDefaultMasterPlaylistName,
                                             kDefaultAudioLanguage,
                                             kDefaultTextLanguage,
+                                  {},
+                                  {},
                                             !kIsIndependentSegments,
                                             kCreateSessionKeys)),
         test_output_dir_("memory://test_dir"),
@@ -189,9 +191,13 @@ TEST_F(MasterPlaylistTest,
   const uint64_t kMaxBitrate = 435889;
   const uint64_t kAvgBitrate = 235889;
 
-  master_playlist_.reset(
-      new MasterPlaylist(kDefaultMasterPlaylistName, kDefaultAudioLanguage,
-                         kDefaultTextLanguage, kIsIndependentSegments));
+  master_playlist_.reset(new MasterPlaylist(kDefaultMasterPlaylistName,
+                                              kDefaultAudioLanguage,
+                                              kDefaultTextLanguage,
+                                              {},
+                                              {},
+                                              kIsIndependentSegments,
+                                              false));
 
   std::unique_ptr<MockMediaPlaylist> mock_playlist =
       CreateVideoPlaylist("media1.m3u8", "avc1", kMaxBitrate, kAvgBitrate);
@@ -1056,6 +1062,51 @@ TEST_F(MasterPlaylistTest, WriteMasterPlaylistAudioOnlyAC4CBI) {
       "#EXT-X-STREAM-INF:BANDWIDTH=50000,AVERAGE-BANDWIDTH=30000,"
       "CODECS=\"audiocodec\",AUDIO=\"audio-group-2\",CLOSED-CAPTIONS=NONE\n"
       "http://playlists.org/audio-2.m3u8\n";
+
+  ASSERT_EQ(expected, actual);
+}
+
+TEST_F(MasterPlaylistTest, WriteMasterPlaylistWithCea608) {
+  const uint64_t kMaxBitrate = 435889;
+  const uint64_t kAvgBitrate = 235889;
+
+  std::vector<CeaCaption> cea608;
+  cea608.push_back({"fr", "fre", "CC1", true, true});
+  cea608.push_back({"en", "eng", "CC2", false, true});
+  master_playlist_.reset(new MasterPlaylist(kDefaultMasterPlaylistName,
+                                            kDefaultAudioLanguage,
+                                            kDefaultTextLanguage,
+                                            cea608,
+                                            {},
+                                            !kIsIndependentSegments,
+                                            false));
+
+  std::unique_ptr<MockMediaPlaylist> mock_playlist =
+      CreateVideoPlaylist("media1.m3u8", "avc1", kMaxBitrate, kAvgBitrate);
+
+  const char kBaseUrl[] = "http://myplaylistdomain.com/";
+  EXPECT_TRUE(master_playlist_->WriteMasterPlaylist(kBaseUrl, test_output_dir_,
+                                                   {mock_playlist.get()}));
+  std::string actual;
+  ASSERT_TRUE(
+      File::ReadFileToString(master_playlist_path_.string().c_str(), &actual));
+
+  const std::string expected =
+      "#EXTM3U\n"
+      "## Generated with https://github.com/shaka-project/shaka-packager "
+      "version test\n"
+      "\n"
+      "#EXT-X-MEDIA:TYPE=CLOSED-CAPTIONS,GROUP-ID=\"CC1\",NAME=\"fr\","
+      "LANGUAGE=\"fre\",DEFAULT=YES,AUTOSELECT=YES,INSTREAM-ID=\"CC1\"\n"
+      "#EXT-X-MEDIA:TYPE=CLOSED-CAPTIONS,GROUP-ID=\"CC2\",NAME=\"en\","
+      "LANGUAGE=\"eng\",DEFAULT=NO,AUTOSELECT=YES,INSTREAM-ID=\"CC2\"\n"
+      "\n"
+      "#EXT-X-STREAM-INF:BANDWIDTH=435889,AVERAGE-BANDWIDTH=235889,"
+      "CODECS=\"avc1\",RESOLUTION=800x600,CLOSED-CAPTIONS=\"CC1\"\n"
+      "http://myplaylistdomain.com/media1.m3u8\n\n"
+      "#EXT-X-STREAM-INF:BANDWIDTH=435889,AVERAGE-BANDWIDTH=235889,"
+      "CODECS=\"avc1\",RESOLUTION=800x600,CLOSED-CAPTIONS=\"CC2\"\n"
+      "http://myplaylistdomain.com/media1.m3u8\n";
 
   ASSERT_EQ(expected, actual);
 }

--- a/packager/hls/base/simple_hls_notifier.cc
+++ b/packager/hls/base/simple_hls_notifier.cc
@@ -16,6 +16,7 @@
 #include <absl/strings/escaping.h>
 #include <absl/strings/numbers.h>
 
+#include <packager/hls/base/master_playlist.h>
 #include <packager/file/file_util.h>
 #include <packager/media/base/protection_system_ids.h>
 #include <packager/media/base/protection_system_specific_info.h>
@@ -285,10 +286,23 @@ SimpleHlsNotifier::SimpleHlsNotifier(const HlsParams& hls_params)
       hls_params.default_text_language.empty()
           ? hls_params.default_language
           : hls_params.default_text_language;
+
+  std::vector<CeaCaption> cea608;
+  for (const auto& caption : hls_params.cea608) {
+    cea608.push_back({caption.name, caption.language, caption.channel,
+                       caption.is_default, caption.autoselect});
+  }
+
+  std::vector<CeaCaption> cea708;
+  for (const auto& caption : hls_params.cea708) {
+    cea708.push_back({caption.name, caption.language, caption.channel,
+                       caption.is_default, caption.autoselect});
+  }
+
   master_playlist_.reset(new MasterPlaylist(
       master_playlist_path.filename(), default_audio_langauge,
-      default_text_language, hls_params.is_independent_segments,
-      hls_params.create_session_keys));
+      default_text_language, cea608, cea708,
+      hls_params.is_independent_segments, hls_params.create_session_keys));
 }
 
 SimpleHlsNotifier::~SimpleHlsNotifier() {}

--- a/packager/hls/base/simple_hls_notifier.cc
+++ b/packager/hls/base/simple_hls_notifier.cc
@@ -290,13 +290,13 @@ SimpleHlsNotifier::SimpleHlsNotifier(const HlsParams& hls_params)
   std::vector<CeaCaption> closed_captions;
   for (const auto& caption : hls_params.closed_captions) {
     closed_captions.push_back({caption.name, caption.language, caption.channel,
-                      caption.is_default, caption.autoselect});
+                               caption.is_default, caption.autoselect});
   }
 
   master_playlist_.reset(new MasterPlaylist(
       master_playlist_path.filename(), default_audio_langauge,
-      default_text_language, closed_captions, hls_params.is_independent_segments,
-      hls_params.create_session_keys));
+      default_text_language, closed_captions,
+      hls_params.is_independent_segments, hls_params.create_session_keys));
 }
 
 SimpleHlsNotifier::~SimpleHlsNotifier() {}

--- a/packager/hls/base/simple_hls_notifier.cc
+++ b/packager/hls/base/simple_hls_notifier.cc
@@ -16,8 +16,8 @@
 #include <absl/strings/escaping.h>
 #include <absl/strings/numbers.h>
 
-#include <packager/hls/base/master_playlist.h>
 #include <packager/file/file_util.h>
+#include <packager/hls/base/master_playlist.h>
 #include <packager/media/base/protection_system_ids.h>
 #include <packager/media/base/protection_system_specific_info.h>
 #include <packager/media/base/proto_json_util.h>
@@ -290,19 +290,19 @@ SimpleHlsNotifier::SimpleHlsNotifier(const HlsParams& hls_params)
   std::vector<CeaCaption> cea608;
   for (const auto& caption : hls_params.cea608) {
     cea608.push_back({caption.name, caption.language, caption.channel,
-                       caption.is_default, caption.autoselect});
+                      caption.is_default, caption.autoselect});
   }
 
   std::vector<CeaCaption> cea708;
   for (const auto& caption : hls_params.cea708) {
     cea708.push_back({caption.name, caption.language, caption.channel,
-                       caption.is_default, caption.autoselect});
+                      caption.is_default, caption.autoselect});
   }
 
   master_playlist_.reset(new MasterPlaylist(
       master_playlist_path.filename(), default_audio_langauge,
-      default_text_language, cea608, cea708,
-      hls_params.is_independent_segments, hls_params.create_session_keys));
+      default_text_language, cea608, cea708, hls_params.is_independent_segments,
+      hls_params.create_session_keys));
 }
 
 SimpleHlsNotifier::~SimpleHlsNotifier() {}

--- a/packager/hls/base/simple_hls_notifier.cc
+++ b/packager/hls/base/simple_hls_notifier.cc
@@ -287,21 +287,15 @@ SimpleHlsNotifier::SimpleHlsNotifier(const HlsParams& hls_params)
           ? hls_params.default_language
           : hls_params.default_text_language;
 
-  std::vector<CeaCaption> cea608;
-  for (const auto& caption : hls_params.cea608) {
-    cea608.push_back({caption.name, caption.language, caption.channel,
-                      caption.is_default, caption.autoselect});
-  }
-
-  std::vector<CeaCaption> cea708;
-  for (const auto& caption : hls_params.cea708) {
-    cea708.push_back({caption.name, caption.language, caption.channel,
+  std::vector<CeaCaption> closed_captions;
+  for (const auto& caption : hls_params.closed_captions) {
+    closed_captions.push_back({caption.name, caption.language, caption.channel,
                       caption.is_default, caption.autoselect});
   }
 
   master_playlist_.reset(new MasterPlaylist(
       master_playlist_path.filename(), default_audio_langauge,
-      default_text_language, cea608, cea708, hls_params.is_independent_segments,
+      default_text_language, closed_captions, hls_params.is_independent_segments,
       hls_params.create_session_keys));
 }
 

--- a/packager/hls/base/simple_hls_notifier_unittest.cc
+++ b/packager/hls/base/simple_hls_notifier_unittest.cc
@@ -53,6 +53,8 @@ class MockMasterPlaylist : public MasterPlaylist {
       : MasterPlaylist(kMasterPlaylistName,
                        kDefaultAudioLanguage,
                        kDefaultTextLanguage,
+                       {},
+                       {},
                        kIsIndependentSegments) {}
 
   MOCK_METHOD3(WriteMasterPlaylist,


### PR DESCRIPTION
This change introduces support for signaling CEA-608 and CEA-708 closed captions in HLS.

New command-line flags, `--closed_captions`, have been added to allow users to specify the caption tracks. The format for these flags is a comma-separated list of semicolon-separated key-value pairs, e.g., 

`--closed_captions
"channel=CC1,name=French,lang=fra,default=no,autoselect=yes;channel=SERVICE1,name=English,lang=eng,default=yes,autoselect=yes"`.

For HLS, this change adds `#EXT-X-MEDIA` tags for each caption track with a common `GROUP-ID` of "cc". The `EXT-X-STREAM-INF` tag for video streams has been updated to reference this `GROUP-ID`.

Dash will be supported in another PR.

Fixes #986