### PR TITLE
feat: Switch VOD to live stream when event/live streams end

### DIFF
--- a/include/packager/hls_params.h
+++ b/include/packager/hls_params.h
@@ -25,6 +25,8 @@ enum class HlsPlaylistType {
 struct HlsParams {
   /// HLS playlist type. See HLS specification for details.
   HlsPlaylistType playlist_type = HlsPlaylistType::kVod;
+  /// Convert event stream to VOD once end of stream is detected
+  bool event_to_vod_on_end_of_stream = false;
   /// HLS master playlist output path.
   std::string master_playlist_output;
   /// The base URL for the Media Playlists and media files listed in the

--- a/include/packager/mpd_params.h
+++ b/include/packager/mpd_params.h
@@ -16,6 +16,8 @@ namespace shaka {
 struct MpdParams {
   /// MPD output file path.
   std::string mpd_output;
+  /// Convert event stream to VOD once end of stream is detected
+  bool event_to_vod_on_end_of_stream = false;
   /// BaseURLs for the MPD. The values will be added as <BaseURL> element(s)
   /// under the <MPD> element.
   std::vector<std::string> base_urls;

--- a/packager/app/manifest_flags.cc
+++ b/packager/app/manifest_flags.cc
@@ -11,6 +11,11 @@ ABSL_FLAG(double,
           1800.0,
           "Guaranteed duration of the time shifting buffer for HLS LIVE "
           "playlists and DASH dynamic media presentations, in seconds.");
+ABSL_FLAG(bool,
+		event_to_vod_on_end_of_stream,
+		false,
+		"Set to true to convert an event stream to VOD in place "
+		"once end of stream is detected");
 ABSL_FLAG(
     uint64_t,
     preserved_segments_outside_live_window,

--- a/packager/app/manifest_flags.cc
+++ b/packager/app/manifest_flags.cc
@@ -12,10 +12,10 @@ ABSL_FLAG(double,
           "Guaranteed duration of the time shifting buffer for HLS LIVE "
           "playlists and DASH dynamic media presentations, in seconds.");
 ABSL_FLAG(bool,
-		event_to_vod_on_end_of_stream,
-		false,
-		"Set to true to convert an event stream to VOD in place "
-		"once end of stream is detected");
+          event_to_vod_on_end_of_stream,
+          false,
+          "Set to true to convert an event stream to VOD in place "
+          "once end of stream is detected");
 ABSL_FLAG(
     uint64_t,
     preserved_segments_outside_live_window,

--- a/packager/app/manifest_flags.h
+++ b/packager/app/manifest_flags.h
@@ -15,6 +15,7 @@
 #include <absl/flags/flag.h>
 
 ABSL_DECLARE_FLAG(double, time_shift_buffer_depth);
+ABSL_DECLARE_FLAG(bool, event_to_vod_on_end_of_stream);
 ABSL_DECLARE_FLAG(uint64_t, preserved_segments_outside_live_window);
 ABSL_DECLARE_FLAG(std::string, default_language);
 ABSL_DECLARE_FLAG(std::string, default_text_language);

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -480,11 +480,11 @@ std::optional<PackagingParams> GetPackagingParams() {
       absl::GetFlag(FLAGS_transport_stream_timestamp_offset_ms);
   packaging_params.default_text_zero_bias_ms =
       absl::GetFlag(FLAGS_default_text_zero_bias_ms);
-
   packaging_params.output_media_info = absl::GetFlag(FLAGS_output_media_info);
 
   MpdParams& mpd_params = packaging_params.mpd_params;
   mpd_params.mpd_output = absl::GetFlag(FLAGS_mpd_output);
+  mpd_params.event_to_vod_on_end_of_stream = absl::GetFlag(FLAGS_event_to_vod_on_end_of_stream);
 
   std::vector<std::string> base_urls =
       SplitAndTrimSkipEmpty(absl::GetFlag(FLAGS_base_urls), ',');
@@ -530,6 +530,7 @@ std::optional<PackagingParams> GetPackagingParams() {
                           &hls_params.playlist_type)) {
     return std::nullopt;
   }
+  hls_params.event_to_vod_on_end_of_stream = absl::GetFlag(FLAGS_event_to_vod_on_end_of_stream);
   hls_params.master_playlist_output =
       absl::GetFlag(FLAGS_hls_master_playlist_output);
   hls_params.base_url = absl::GetFlag(FLAGS_hls_base_url);

--- a/packager/app/packager_main.cc
+++ b/packager/app/packager_main.cc
@@ -484,7 +484,8 @@ std::optional<PackagingParams> GetPackagingParams() {
 
   MpdParams& mpd_params = packaging_params.mpd_params;
   mpd_params.mpd_output = absl::GetFlag(FLAGS_mpd_output);
-  mpd_params.event_to_vod_on_end_of_stream = absl::GetFlag(FLAGS_event_to_vod_on_end_of_stream);
+  mpd_params.event_to_vod_on_end_of_stream =
+      absl::GetFlag(FLAGS_event_to_vod_on_end_of_stream);
 
   std::vector<std::string> base_urls =
       SplitAndTrimSkipEmpty(absl::GetFlag(FLAGS_base_urls), ',');
@@ -530,7 +531,8 @@ std::optional<PackagingParams> GetPackagingParams() {
                           &hls_params.playlist_type)) {
     return std::nullopt;
   }
-  hls_params.event_to_vod_on_end_of_stream = absl::GetFlag(FLAGS_event_to_vod_on_end_of_stream);
+  hls_params.event_to_vod_on_end_of_stream =
+      absl::GetFlag(FLAGS_event_to_vod_on_end_of_stream);
   hls_params.master_playlist_output =
       absl::GetFlag(FLAGS_hls_master_playlist_output);
   hls_params.base_url = absl::GetFlag(FLAGS_hls_base_url);

--- a/packager/hls/base/hls_notifier.h
+++ b/packager/hls/base/hls_notifier.h
@@ -97,6 +97,8 @@ class HlsNotifier {
       const std::vector<uint8_t>& iv,
       const std::vector<uint8_t>& protection_system_specific_data) = 0;
 
+  virtual bool NotifyEndOfStream() = 0;
+
   /// Process any current buffered states/resources.
   /// @return true on success, false otherwise.
   virtual bool Flush() = 0;

--- a/packager/hls/base/media_playlist.cc
+++ b/packager/hls/base/media_playlist.cc
@@ -510,20 +510,25 @@ void MediaPlaylist::AddPlacementOpportunity() {
   entries_.emplace_back(new PlacementOpportunityEntry());
 }
 
-bool MediaPlaylist::WriteToFile(const std::filesystem::path& file_path) {
+bool MediaPlaylist::WriteToFile(const std::filesystem::path& file_path, const bool event_to_vod_on_end_of_stream, const bool end_stream) {
   if (!target_duration_set_) {
     SetTargetDuration(ceil(GetLongestSegmentDuration()));
   }
 
+  HlsPlaylistType playlist_type = hls_params_.playlist_type;
+  if (event_to_vod_on_end_of_stream && end_stream && playlist_type == HlsPlaylistType::kEvent) {
+	  playlist_type = HlsPlaylistType::kVod;
+  }
+
   std::string content = CreatePlaylistHeader(
-      media_info_, target_duration_, hls_params_.playlist_type, stream_type_,
+      media_info_, target_duration_, playlist_type, stream_type_,
       media_sequence_number_, discontinuity_sequence_number_,
       hls_params_.start_time_offset);
 
   for (const auto& entry : entries_)
     absl::StrAppendFormat(&content, "%s\n", entry->ToString().c_str());
 
-  if (hls_params_.playlist_type == HlsPlaylistType::kVod) {
+  if (playlist_type == HlsPlaylistType::kVod) {
     content += "#EXT-X-ENDLIST\n";
   }
 

--- a/packager/hls/base/media_playlist.cc
+++ b/packager/hls/base/media_playlist.cc
@@ -510,14 +510,17 @@ void MediaPlaylist::AddPlacementOpportunity() {
   entries_.emplace_back(new PlacementOpportunityEntry());
 }
 
-bool MediaPlaylist::WriteToFile(const std::filesystem::path& file_path, const bool event_to_vod_on_end_of_stream, const bool end_stream) {
+bool MediaPlaylist::WriteToFile(const std::filesystem::path& file_path,
+                                const bool event_to_vod_on_end_of_stream,
+                                const bool end_stream) {
   if (!target_duration_set_) {
     SetTargetDuration(ceil(GetLongestSegmentDuration()));
   }
 
   HlsPlaylistType playlist_type = hls_params_.playlist_type;
-  if (event_to_vod_on_end_of_stream && end_stream && playlist_type == HlsPlaylistType::kEvent) {
-	  playlist_type = HlsPlaylistType::kVod;
+  if (event_to_vod_on_end_of_stream && end_stream &&
+      playlist_type == HlsPlaylistType::kEvent) {
+    playlist_type = HlsPlaylistType::kVod;
   }
 
   std::string content = CreatePlaylistHeader(

--- a/packager/hls/base/media_playlist.cc
+++ b/packager/hls/base/media_playlist.cc
@@ -511,8 +511,8 @@ void MediaPlaylist::AddPlacementOpportunity() {
 }
 
 bool MediaPlaylist::WriteToFile(const std::filesystem::path& file_path,
-                                const bool event_to_vod_on_end_of_stream,
-                                const bool end_stream) {
+                                bool event_to_vod_on_end_of_stream,
+                                bool end_stream) {
   if (!target_duration_set_) {
     SetTargetDuration(ceil(GetLongestSegmentDuration()));
   }

--- a/packager/hls/base/media_playlist.h
+++ b/packager/hls/base/media_playlist.h
@@ -184,8 +184,10 @@ class MediaPlaylist {
   /// generate an invalid playlist.
   /// @param file_path is the output file path accepted by the File
   ///        implementation.
+  /// @param event_to_vod_on_end_of_stream whether the playlist should be converted to a vod stream once the event/live stream has ended
+  /// @param end_stream whether the stream has ended and this is the final time we will write to the file
   /// @return true on success, false otherwise.
-  virtual bool WriteToFile(const std::filesystem::path& file_path);
+  virtual bool WriteToFile(const std::filesystem::path& file_path, const bool event_to_vod_on_end_of_stream, const bool end_stream);
 
   /// If bitrate is specified in MediaInfo then it will use that value.
   /// Otherwise, returns the max bitrate.

--- a/packager/hls/base/media_playlist.h
+++ b/packager/hls/base/media_playlist.h
@@ -184,10 +184,14 @@ class MediaPlaylist {
   /// generate an invalid playlist.
   /// @param file_path is the output file path accepted by the File
   ///        implementation.
-  /// @param event_to_vod_on_end_of_stream whether the playlist should be converted to a vod stream once the event/live stream has ended
-  /// @param end_stream whether the stream has ended and this is the final time we will write to the file
+  /// @param event_to_vod_on_end_of_stream whether the playlist should be
+  /// converted to a vod stream once the event/live stream has ended
+  /// @param end_stream whether the stream has ended and this is the final time
+  /// we will write to the file
   /// @return true on success, false otherwise.
-  virtual bool WriteToFile(const std::filesystem::path& file_path, const bool event_to_vod_on_end_of_stream, const bool end_stream);
+  virtual bool WriteToFile(const std::filesystem::path& file_path,
+                           const bool event_to_vod_on_end_of_stream,
+                           const bool end_stream);
 
   /// If bitrate is specified in MediaInfo then it will use that value.
   /// Otherwise, returns the max bitrate.

--- a/packager/hls/base/media_playlist.h
+++ b/packager/hls/base/media_playlist.h
@@ -190,8 +190,8 @@ class MediaPlaylist {
   /// we will write to the file
   /// @return true on success, false otherwise.
   virtual bool WriteToFile(const std::filesystem::path& file_path,
-                           const bool event_to_vod_on_end_of_stream,
-                           const bool end_stream);
+                           bool event_to_vod_on_end_of_stream,
+                           bool end_stream);
 
   /// If bitrate is specified in MediaInfo then it will use that value.
   /// Otherwise, returns the max bitrate.

--- a/packager/hls/base/media_playlist_unittest.cc
+++ b/packager/hls/base/media_playlist_unittest.cc
@@ -170,7 +170,7 @@ TEST_F(MediaPlaylistSingleSegmentTest, InitRange) {
 
   ASSERT_TRUE(media_playlist_->SetMediaInfo(valid_video_media_info_));
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -190,7 +190,7 @@ TEST_F(MediaPlaylistSingleSegmentTest, InitRangeWithOffset) {
 
   ASSERT_TRUE(media_playlist_->SetMediaInfo(valid_video_media_info_));
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -224,7 +224,7 @@ TEST_F(MediaPlaylistSingleSegmentTest, AddSegmentByteRange) {
                               1001000, 2 * kMBytes);
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -248,7 +248,7 @@ TEST_F(MediaPlaylistMultiSegmentTest, WriteToFile) {
       "#EXT-X-ENDLIST\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -300,7 +300,7 @@ TEST_F(MediaPlaylistMultiSegmentTest, SetTargetDuration) {
       "#EXT-X-ENDLIST\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -326,7 +326,7 @@ TEST_F(MediaPlaylistMultiSegmentTest, WriteToFileWithSegments) {
       "#EXT-X-ENDLIST\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -355,7 +355,7 @@ TEST_F(MediaPlaylistMultiSegmentTest,
       "#EXT-X-ENDLIST\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -387,7 +387,7 @@ TEST_F(MediaPlaylistMultiSegmentTest, WriteToFileWithEncryptionInfo) {
       "#EXT-X-ENDLIST\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -418,7 +418,7 @@ TEST_F(MediaPlaylistMultiSegmentTest, WriteToFileWithEncryptionInfoEmptyIv) {
       "#EXT-X-ENDLIST\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -453,7 +453,7 @@ TEST_F(MediaPlaylistMultiSegmentTest, WriteToFileWithClearLead) {
       "#EXT-X-ENDLIST\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -584,7 +584,7 @@ TEST_F(MediaPlaylistMultiSegmentTest, InitSegment) {
       "#EXT-X-ENDLIST\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -618,7 +618,7 @@ TEST_F(MediaPlaylistMultiSegmentTest, SampleAesCenc) {
       "#EXT-X-ENDLIST\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -658,7 +658,7 @@ TEST_F(MediaPlaylistMultiSegmentTest, MultipleEncryptionInfo) {
       "#EXT-X-ENDLIST\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -678,7 +678,7 @@ TEST_F(MediaPlaylistSingleSegmentTest, StartTimeEmpty) {
   ASSERT_TRUE(media_playlist_->SetMediaInfo(valid_video_media_info_));
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false, true));
 
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
@@ -699,7 +699,7 @@ TEST_F(MediaPlaylistSingleSegmentTest, StartTimeZero) {
   ASSERT_TRUE(media_playlist_->SetMediaInfo(valid_video_media_info_));
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false, true));
 
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
@@ -720,7 +720,7 @@ TEST_F(MediaPlaylistSingleSegmentTest, StartTimePositive) {
   ASSERT_TRUE(media_playlist_->SetMediaInfo(valid_video_media_info_));
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false, true));
 
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
@@ -741,7 +741,7 @@ TEST_F(MediaPlaylistSingleSegmentTest, StartTimeNegative) {
   ASSERT_TRUE(media_playlist_->SetMediaInfo(valid_video_media_info_));
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false, true));
 
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
@@ -771,7 +771,7 @@ TEST_F(LiveMediaPlaylistTest, Basic) {
       "file2.ts\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false, false));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -797,7 +797,7 @@ TEST_F(LiveMediaPlaylistTest, TimeShifted) {
       "file3.ts\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false, false));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -837,7 +837,7 @@ TEST_F(LiveMediaPlaylistTest, TimeShiftedWithEncryptionInfo) {
       "file3.ts\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false, false));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -904,7 +904,7 @@ TEST_F(LiveMediaPlaylistTest, TimeShiftedWithEncryptionInfoShifted) {
       "file4.ts\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false, false));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -934,7 +934,32 @@ TEST_F(EventMediaPlaylistTest, Basic) {
       "file2.ts\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false, false));
+  ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
+}
+
+TEST_F(EventMediaPlaylistTest, CompletedAtEnd) {
+  ASSERT_TRUE(media_playlist_->SetMediaInfo(valid_video_media_info_));
+
+  media_playlist_->AddSegment("file1.ts", 0, 10 * kTimeScale, kZeroByteOffset,
+                              kMBytes);
+  media_playlist_->AddSegment("file2.ts", 10 * kTimeScale, 20 * kTimeScale,
+                              kZeroByteOffset, 2 * kMBytes);
+  const char kExpectedOutput[] =
+      "#EXTM3U\n"
+      "#EXT-X-VERSION:6\n"
+      "## Generated with https://github.com/shaka-project/shaka-packager "
+      "version test\n"
+      "#EXT-X-TARGETDURATION:20\n"
+      "#EXT-X-PLAYLIST-TYPE:VOD\n"
+      "#EXTINF:10.000,\n"
+      "file1.ts\n"
+      "#EXTINF:20.000,\n"
+      "file2.ts\n"
+      "#EXT-X-ENDLIST\n";
+
+  const char kMemoryFilePath[] = "memory://media.m3u8";
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, true, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -990,7 +1015,7 @@ TEST_F(IFrameMediaPlaylistTest, SingleSegment) {
       "#EXT-X-ENDLIST\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -1031,7 +1056,7 @@ TEST_F(IFrameMediaPlaylistTest, MultiSegment) {
       "#EXT-X-ENDLIST\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -1074,7 +1099,7 @@ TEST_F(IFrameMediaPlaylistTest, MultiSegmentWithPlacementOpportunity) {
       "#EXT-X-ENDLIST\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -1259,7 +1284,7 @@ TEST_F(MediaPlaylistMultiSegmentTest, ProgramDateTime) {
       "#EXT-X-ENDLIST\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
 
@@ -1307,8 +1332,9 @@ TEST_F(MediaPlaylistMultiSegmentTest, ProgramDateTimeWithDiscontinuity) {
       "#EXT-X-ENDLIST\n";
 
   const char kMemoryFilePath[] = "memory://media.m3u8";
-  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath));
+  EXPECT_TRUE(media_playlist_->WriteToFile(kMemoryFilePath, false, true));
   ASSERT_FILE_STREQ(kMemoryFilePath, kExpectedOutput);
 }
+
 }  // namespace hls
 }  // namespace shaka

--- a/packager/hls/base/mock_media_playlist.h
+++ b/packager/hls/base/mock_media_playlist.h
@@ -46,8 +46,8 @@ class MockMediaPlaylist : public MediaPlaylist {
   MOCK_METHOD0(AddPlacementOpportunity, void());
   MOCK_METHOD3(WriteToFile,
                bool(const std::filesystem::path& file_path,
-                    const bool event_to_vod_on_end_of_stream,
-                    const bool end_stream));
+                    bool event_to_vod_on_end_of_stream,
+                    bool end_stream));
   MOCK_CONST_METHOD0(MaxBitrate, uint64_t());
   MOCK_CONST_METHOD0(AvgBitrate, uint64_t());
   MOCK_CONST_METHOD0(GetLongestSegmentDuration, double());

--- a/packager/hls/base/mock_media_playlist.h
+++ b/packager/hls/base/mock_media_playlist.h
@@ -44,7 +44,7 @@ class MockMediaPlaylist : public MediaPlaylist {
                     const std::string& key_format,
                     const std::string& key_format_versions));
   MOCK_METHOD0(AddPlacementOpportunity, void());
-  MOCK_METHOD1(WriteToFile, bool(const std::filesystem::path& file_path));
+  MOCK_METHOD3(WriteToFile, bool(const std::filesystem::path& file_path, const bool event_to_vod_on_end_of_stream, const bool end_stream));
   MOCK_CONST_METHOD0(MaxBitrate, uint64_t());
   MOCK_CONST_METHOD0(AvgBitrate, uint64_t());
   MOCK_CONST_METHOD0(GetLongestSegmentDuration, double());

--- a/packager/hls/base/mock_media_playlist.h
+++ b/packager/hls/base/mock_media_playlist.h
@@ -44,7 +44,10 @@ class MockMediaPlaylist : public MediaPlaylist {
                     const std::string& key_format,
                     const std::string& key_format_versions));
   MOCK_METHOD0(AddPlacementOpportunity, void());
-  MOCK_METHOD3(WriteToFile, bool(const std::filesystem::path& file_path, const bool event_to_vod_on_end_of_stream, const bool end_stream));
+  MOCK_METHOD3(WriteToFile,
+               bool(const std::filesystem::path& file_path,
+                    const bool event_to_vod_on_end_of_stream,
+                    const bool end_stream));
   MOCK_CONST_METHOD0(MaxBitrate, uint64_t());
   MOCK_CONST_METHOD0(AvgBitrate, uint64_t());
   MOCK_CONST_METHOD0(GetLongestSegmentDuration, double());

--- a/packager/hls/base/simple_hls_notifier.cc
+++ b/packager/hls/base/simple_hls_notifier.cc
@@ -249,13 +249,13 @@ bool HandleWidevineKeyFormats(
 }
 
 bool WriteMediaPlaylist(const std::string& output_dir,
-                        MediaPlaylist* playlist) {
+                        MediaPlaylist* playlist, const bool event_to_vod_on_end_of_stream, const bool end_stream) {
   auto file_path = std::filesystem::u8path(output_dir) / playlist->file_name();
-  if (!playlist->WriteToFile(file_path)) {
+  if (!playlist->WriteToFile(file_path, event_to_vod_on_end_of_stream, end_stream)) {
     LOG(ERROR) << "Failed to write playlist " << file_path.string();
     return false;
   }
-  return true;
+    return true;
 }
 
 }  // namespace
@@ -318,7 +318,7 @@ bool SimpleHlsNotifier::NotifyNewStream(const MediaInfo& media_info,
     return false;
   }
   media_playlist->SetReferenceTime(reference_time());
-
+  
   MediaPlaylist::EncryptionMethod encryption_method =
       MediaPlaylist::EncryptionMethod::kNone;
   if (media_info.protected_content().has_protection_scheme()) {
@@ -390,11 +390,11 @@ bool SimpleHlsNotifier::NotifyNewSegment(uint32_t stream_id,
     if (target_duration_updated) {
       for (MediaPlaylist* playlist : media_playlists_) {
         playlist->SetTargetDuration(target_duration_);
-        if (!WriteMediaPlaylist(master_playlist_dir_, playlist))
+        if (!WriteMediaPlaylist(master_playlist_dir_, playlist, hls_params().event_to_vod_on_end_of_stream, end_stream))
           return false;
       }
     } else {
-      if (!WriteMediaPlaylist(master_playlist_dir_, media_playlist.get()))
+      if (!WriteMediaPlaylist(master_playlist_dir_, media_playlist.get(), hls_params().event_to_vod_on_end_of_stream, end_stream))
         return false;
     }
     if (!master_playlist_->WriteMasterPlaylist(
@@ -524,11 +524,16 @@ bool SimpleHlsNotifier::NotifyEncryptionUpdate(
   return true;
 }
 
+bool SimpleHlsNotifier::NotifyEndOfStream() {
+	end_stream = true;
+	return true;
+}
+
 bool SimpleHlsNotifier::Flush() {
   absl::MutexLock lock(&lock_);
   for (MediaPlaylist* playlist : media_playlists_) {
     playlist->SetTargetDuration(target_duration_);
-    if (!WriteMediaPlaylist(master_playlist_dir_, playlist))
+    if (!WriteMediaPlaylist(master_playlist_dir_, playlist, hls_params().event_to_vod_on_end_of_stream, end_stream))
       return false;
   }
   if (!master_playlist_->WriteMasterPlaylist(

--- a/packager/hls/base/simple_hls_notifier.cc
+++ b/packager/hls/base/simple_hls_notifier.cc
@@ -249,13 +249,16 @@ bool HandleWidevineKeyFormats(
 }
 
 bool WriteMediaPlaylist(const std::string& output_dir,
-                        MediaPlaylist* playlist, const bool event_to_vod_on_end_of_stream, const bool end_stream) {
+                        MediaPlaylist* playlist,
+                        const bool event_to_vod_on_end_of_stream,
+                        const bool end_stream) {
   auto file_path = std::filesystem::u8path(output_dir) / playlist->file_name();
-  if (!playlist->WriteToFile(file_path, event_to_vod_on_end_of_stream, end_stream)) {
+  if (!playlist->WriteToFile(file_path, event_to_vod_on_end_of_stream,
+                             end_stream)) {
     LOG(ERROR) << "Failed to write playlist " << file_path.string();
     return false;
   }
-    return true;
+  return true;
 }
 
 }  // namespace
@@ -318,7 +321,7 @@ bool SimpleHlsNotifier::NotifyNewStream(const MediaInfo& media_info,
     return false;
   }
   media_playlist->SetReferenceTime(reference_time());
-  
+
   MediaPlaylist::EncryptionMethod encryption_method =
       MediaPlaylist::EncryptionMethod::kNone;
   if (media_info.protected_content().has_protection_scheme()) {
@@ -390,11 +393,15 @@ bool SimpleHlsNotifier::NotifyNewSegment(uint32_t stream_id,
     if (target_duration_updated) {
       for (MediaPlaylist* playlist : media_playlists_) {
         playlist->SetTargetDuration(target_duration_);
-        if (!WriteMediaPlaylist(master_playlist_dir_, playlist, hls_params().event_to_vod_on_end_of_stream, end_stream))
+        if (!WriteMediaPlaylist(master_playlist_dir_, playlist,
+                                hls_params().event_to_vod_on_end_of_stream,
+                                end_stream))
           return false;
       }
     } else {
-      if (!WriteMediaPlaylist(master_playlist_dir_, media_playlist.get(), hls_params().event_to_vod_on_end_of_stream, end_stream))
+      if (!WriteMediaPlaylist(master_playlist_dir_, media_playlist.get(),
+                              hls_params().event_to_vod_on_end_of_stream,
+                              end_stream))
         return false;
     }
     if (!master_playlist_->WriteMasterPlaylist(
@@ -525,8 +532,8 @@ bool SimpleHlsNotifier::NotifyEncryptionUpdate(
 }
 
 bool SimpleHlsNotifier::NotifyEndOfStream() {
-	end_stream = true;
-	return true;
+  end_stream = true;
+  return true;
 }
 
 bool SimpleHlsNotifier::Flush() {
@@ -538,7 +545,9 @@ bool SimpleHlsNotifier::Flush() {
     } else {
       playlist->SetTargetDuration(target_duration_);
     }
-    if (!WriteMediaPlaylist(master_playlist_dir_, playlist, hls_params().event_to_vod_on_end_of_stream, end_stream))
+    if (!WriteMediaPlaylist(master_playlist_dir_, playlist,
+                            hls_params().event_to_vod_on_end_of_stream,
+                            end_stream))
       return false;
   }
   if (!master_playlist_->WriteMasterPlaylist(

--- a/packager/hls/base/simple_hls_notifier.h
+++ b/packager/hls/base/simple_hls_notifier.h
@@ -70,6 +70,9 @@ class SimpleHlsNotifier : public HlsNotifier {
       const std::vector<uint8_t>& system_id,
       const std::vector<uint8_t>& iv,
       const std::vector<uint8_t>& protection_system_specific_data) override;
+
+  bool NotifyEndOfStream() override;
+
   bool Flush() override;
   /// }@
 
@@ -86,6 +89,7 @@ class SimpleHlsNotifier : public HlsNotifier {
 
   std::string master_playlist_dir_;
   int32_t target_duration_ = 0;
+  bool end_stream = false;
 
   std::unique_ptr<MediaPlaylistFactory> media_playlist_factory_;
   std::unique_ptr<MasterPlaylist> master_playlist_;

--- a/packager/hls/base/simple_hls_notifier_unittest.cc
+++ b/packager/hls/base/simple_hls_notifier_unittest.cc
@@ -372,8 +372,9 @@ TEST_F(SimpleHlsNotifierTest, NotifyNewSegment) {
   EXPECT_CALL(*mock_media_playlist, SetTargetDuration(kTargetDuration))
       .Times(1);
   EXPECT_CALL(*mock_media_playlist,
-              WriteToFile(Eq(
-                  (std::filesystem::u8path(kAnyOutputDir) / "playlist.m3u8")), Eq(false), Eq(false)))
+              WriteToFile(Eq((std::filesystem::u8path(kAnyOutputDir) /
+                              "playlist.m3u8")),
+                          Eq(false), Eq(false)))
       .WillOnce(Return(true));
   EXPECT_TRUE(notifier.Flush());
 }
@@ -658,8 +659,9 @@ TEST_P(LiveOrEventSimpleHlsNotifierTest, NotifyNewSegment) {
   EXPECT_CALL(*mock_media_playlist, SetTargetDuration(kTargetDuration))
       .Times(1);
   EXPECT_CALL(*mock_media_playlist,
-              WriteToFile(Eq(
-                  (std::filesystem::u8path(kAnyOutputDir) / "playlist.m3u8")), Eq(false), Eq(false)))
+              WriteToFile(Eq((std::filesystem::u8path(kAnyOutputDir) /
+                              "playlist.m3u8")),
+                          Eq(false), Eq(false)))
       .WillOnce(Return(true));
 
   hls_params_.playlist_type = GetParam();
@@ -726,14 +728,16 @@ TEST_P(LiveOrEventSimpleHlsNotifierTest, NotifyNewSegmentsWithMultipleStreams) {
   EXPECT_CALL(*mock_media_playlist1, SetTargetDuration(kTargetDuration))
       .Times(1);
   EXPECT_CALL(*mock_media_playlist1,
-              WriteToFile(Eq(
-                  (std::filesystem::u8path(kAnyOutputDir) / "playlist1.m3u8")), Eq(false), Eq(false)))
+              WriteToFile(Eq((std::filesystem::u8path(kAnyOutputDir) /
+                              "playlist1.m3u8")),
+                          Eq(false), Eq(false)))
       .WillOnce(Return(true));
   EXPECT_CALL(*mock_media_playlist2, SetTargetDuration(kTargetDuration))
       .Times(1);
   EXPECT_CALL(*mock_media_playlist2,
-              WriteToFile(Eq(
-                  (std::filesystem::u8path(kAnyOutputDir) / "playlist2.m3u8")), Eq(false), Eq(false)))
+              WriteToFile(Eq((std::filesystem::u8path(kAnyOutputDir) /
+                              "playlist2.m3u8")),
+                          Eq(false), Eq(false)))
       .WillOnce(Return(true));
   EXPECT_CALL(
       *mock_master_playlist_ptr,
@@ -748,8 +752,9 @@ TEST_P(LiveOrEventSimpleHlsNotifierTest, NotifyNewSegmentsWithMultipleStreams) {
       .WillOnce(Return(kLongestSegmentDuration));
   // Not updating other playlists as target duration does not change.
   EXPECT_CALL(*mock_media_playlist2,
-              WriteToFile(Eq(
-                  (std::filesystem::u8path(kAnyOutputDir) / "playlist2.m3u8")), Eq(false), Eq(false)))
+              WriteToFile(Eq((std::filesystem::u8path(kAnyOutputDir) /
+                              "playlist2.m3u8")),
+                          Eq(false), Eq(false)))
       .WillOnce(Return(true));
   EXPECT_CALL(*mock_master_playlist_ptr, WriteMasterPlaylist(_, _, _))
       .WillOnce(Return(true));

--- a/packager/hls/base/simple_hls_notifier_unittest.cc
+++ b/packager/hls/base/simple_hls_notifier_unittest.cc
@@ -249,7 +249,7 @@ TEST_F(SimpleHlsNotifierTest, NotifyNewSegment) {
       .Times(1);
   EXPECT_CALL(*mock_media_playlist,
               WriteToFile(Eq(
-                  (std::filesystem::u8path(kAnyOutputDir) / "playlist.m3u8"))))
+                  (std::filesystem::u8path(kAnyOutputDir) / "playlist.m3u8")), Eq(false), Eq(false)))
       .WillOnce(Return(true));
   EXPECT_TRUE(notifier.Flush());
 }
@@ -535,7 +535,7 @@ TEST_P(LiveOrEventSimpleHlsNotifierTest, NotifyNewSegment) {
       .Times(1);
   EXPECT_CALL(*mock_media_playlist,
               WriteToFile(Eq(
-                  (std::filesystem::u8path(kAnyOutputDir) / "playlist.m3u8"))))
+                  (std::filesystem::u8path(kAnyOutputDir) / "playlist.m3u8")), Eq(false), Eq(false)))
       .WillOnce(Return(true));
 
   hls_params_.playlist_type = GetParam();
@@ -603,13 +603,13 @@ TEST_P(LiveOrEventSimpleHlsNotifierTest, NotifyNewSegmentsWithMultipleStreams) {
       .Times(1);
   EXPECT_CALL(*mock_media_playlist1,
               WriteToFile(Eq(
-                  (std::filesystem::u8path(kAnyOutputDir) / "playlist1.m3u8"))))
+                  (std::filesystem::u8path(kAnyOutputDir) / "playlist1.m3u8")), Eq(false), Eq(false)))
       .WillOnce(Return(true));
   EXPECT_CALL(*mock_media_playlist2, SetTargetDuration(kTargetDuration))
       .Times(1);
   EXPECT_CALL(*mock_media_playlist2,
               WriteToFile(Eq(
-                  (std::filesystem::u8path(kAnyOutputDir) / "playlist2.m3u8"))))
+                  (std::filesystem::u8path(kAnyOutputDir) / "playlist2.m3u8")), Eq(false), Eq(false)))
       .WillOnce(Return(true));
   EXPECT_CALL(
       *mock_master_playlist_ptr,
@@ -625,7 +625,7 @@ TEST_P(LiveOrEventSimpleHlsNotifierTest, NotifyNewSegmentsWithMultipleStreams) {
   // Not updating other playlists as target duration does not change.
   EXPECT_CALL(*mock_media_playlist2,
               WriteToFile(Eq(
-                  (std::filesystem::u8path(kAnyOutputDir) / "playlist2.m3u8"))))
+                  (std::filesystem::u8path(kAnyOutputDir) / "playlist2.m3u8")), Eq(false), Eq(false)))
       .WillOnce(Return(true));
   EXPECT_CALL(*mock_master_playlist_ptr, WriteMasterPlaylist(_, _, _))
       .WillOnce(Return(true));

--- a/packager/hls/base/simple_hls_notifier_unittest.cc
+++ b/packager/hls/base/simple_hls_notifier_unittest.cc
@@ -285,12 +285,14 @@ TEST_F(SimpleHlsNotifierTest, LocalTargetDuration) {
                   ElementsAre(mock_media_playlist1, mock_media_playlist2)))
       .WillOnce(Return(true));
   EXPECT_CALL(*mock_media_playlist1,
-              WriteToFile(Eq(
-                  (std::filesystem::u8path(kAnyOutputDir) / "playlist1.m3u8"))))
+              WriteToFile(Eq((std::filesystem::u8path(kAnyOutputDir) /
+                              "playlist1.m3u8")),
+                          Eq(false), Eq(false)))
       .WillOnce(Return(true));
   EXPECT_CALL(*mock_media_playlist2,
-              WriteToFile(Eq(
-                  (std::filesystem::u8path(kAnyOutputDir) / "playlist2.m3u8"))))
+              WriteToFile(Eq((std::filesystem::u8path(kAnyOutputDir) /
+                              "playlist2.m3u8")),
+                          Eq(false), Eq(false)))
       .WillOnce(Return(true));
   EXPECT_TRUE(notifier.Flush());
 }

--- a/packager/media/event/hls_notify_muxer_listener.cc
+++ b/packager/media/event/hls_notify_muxer_listener.cc
@@ -169,6 +169,7 @@ void HlsNotifyMuxerListener::OnMediaEnd(const MediaRanges& media_ranges,
   // before all Media Playlists are read. Which could cause problems
   // setting the correct EXT-X-TARGETDURATION.
   if (media_info_->has_segment_template()) {
+	hls_notifier_->NotifyEndOfStream();
     return;
   }
   if (media_ranges.init_range) {
@@ -239,6 +240,8 @@ void HlsNotifyMuxerListener::OnMediaEnd(const MediaRanges& media_ranges,
     }
   }
   event_info_.clear();
+
+  hls_notifier_->NotifyEndOfStream();
 }
 
 void HlsNotifyMuxerListener::OnNewSegment(const std::string& file_name,

--- a/packager/media/event/hls_notify_muxer_listener.cc
+++ b/packager/media/event/hls_notify_muxer_listener.cc
@@ -169,7 +169,7 @@ void HlsNotifyMuxerListener::OnMediaEnd(const MediaRanges& media_ranges,
   // before all Media Playlists are read. Which could cause problems
   // setting the correct EXT-X-TARGETDURATION.
   if (media_info_->has_segment_template()) {
-	hls_notifier_->NotifyEndOfStream();
+    hls_notifier_->NotifyEndOfStream();
     return;
   }
   if (media_ranges.init_range) {

--- a/packager/media/event/hls_notify_muxer_listener_unittest.cc
+++ b/packager/media/event/hls_notify_muxer_listener_unittest.cc
@@ -61,6 +61,7 @@ class MockHlsNotifier : public hls::HlsNotifier {
            const std::vector<uint8_t>& system_id,
            const std::vector<uint8_t>& iv,
            const std::vector<uint8_t>& protection_system_specific_data));
+  MOCK_METHOD0(NotifyEndOfStream, bool());
   MOCK_METHOD0(Flush, bool());
 };
 
@@ -375,6 +376,8 @@ TEST_F(HlsNotifyMuxerListenerTest, NoSegmentTemplateOnMediaEnd) {
       mock_notifier_,
       NotifyNewSegment(_, StrEq("filename.mp4"), kSegmentStartTime,
                        kSegmentDuration, kSegmentStartOffset, kSegmentSize));
+  EXPECT_CALL(mock_notifier_, NotifyEndOfStream());
+
   listener_.OnMediaEnd(
       GetMediaRanges(
           {{kSegmentStartOffset, kSegmentStartOffset + kSegmentSize - 1}}),
@@ -406,6 +409,8 @@ TEST_F(HlsNotifyMuxerListenerTest, NoSegmentTemplateOnMediaEndTwice) {
   EXPECT_CALL(mock_notifier_, NotifyNewSegment(_, StrEq("filename1.mp4"),
                                                kSegmentStartTime, _, _, _));
   EXPECT_CALL(mock_notifier_, NotifyCueEvent(_, kCueStartTime));
+
+  EXPECT_CALL(mock_notifier_, NotifyEndOfStream());
   listener_.OnMediaEnd(
       GetMediaRanges(
           {{kSegmentStartOffset, kSegmentStartOffset + kSegmentSize - 1}}),
@@ -419,6 +424,8 @@ TEST_F(HlsNotifyMuxerListenerTest, NoSegmentTemplateOnMediaEndTwice) {
   EXPECT_CALL(mock_notifier_,
               NotifyNewSegment(_, StrEq("filename2.mp4"),
                                kSegmentStartTime + kSegmentDuration, _, _, _));
+
+  EXPECT_CALL(mock_notifier_, NotifyEndOfStream());
   listener_.OnMediaEnd(
       GetMediaRanges(
           {{kSegmentStartOffset, kSegmentStartOffset + kSegmentSize - 1}}),
@@ -446,6 +453,8 @@ TEST_F(HlsNotifyMuxerListenerTest,
       mock_notifier_,
       NotifyNewSegment(_, StrEq("filename.mp4"), kSegmentStartTime,
                        kSegmentDuration, kSegmentStartOffset, kSegmentSize));
+  EXPECT_CALL(mock_notifier_, NotifyEndOfStream());
+
   listener_.OnMediaEnd(
       GetMediaRanges(
           {{kSegmentStartOffset, kSegmentStartOffset + kSegmentSize - 1},
@@ -516,6 +525,7 @@ TEST_P(HlsNotifyMuxerListenerKeyFrameTest, NoSegmentTemplate) {
       mock_notifier_,
       NotifyNewSegment(_, StrEq("filename.mp4"), kSegmentStartTime,
                        kSegmentDuration, kSegmentStartOffset, kSegmentSize));
+  EXPECT_CALL(mock_notifier_, NotifyEndOfStream());
 
   MuxerListener::MediaRanges ranges;
   ranges.subsegment_ranges.push_back(

--- a/packager/media/event/mpd_notify_muxer_listener.cc
+++ b/packager/media/event/mpd_notify_muxer_listener.cc
@@ -151,10 +151,15 @@ void MpdNotifyMuxerListener::OnMediaEnd(const MediaRanges& media_ranges,
                                         float duration_seconds) {
   if (mpd_notifier_->dash_profile() == DashProfile::kLive) {
     DCHECK(event_info_.empty());
-    // TODO(kqyang): Set mpd duration to |duration_seconds|, which is more
-    // accurate than the duration coded in the original media header.
+
     if (mpd_notifier_->mpd_type() == MpdType::kStatic)
       mpd_notifier_->Flush();
+    else {
+      // Set mpd duration to |duration_seconds|, which is more
+      // accurate than the duration coded in the original media header.
+	  media_info_->set_media_duration_seconds(duration_seconds);
+      mpd_notifier_->NotifyEndOfStream();
+    }
     return;
   }
 

--- a/packager/media/event/mpd_notify_muxer_listener.cc
+++ b/packager/media/event/mpd_notify_muxer_listener.cc
@@ -157,7 +157,7 @@ void MpdNotifyMuxerListener::OnMediaEnd(const MediaRanges& media_ranges,
     else {
       // Set mpd duration to |duration_seconds|, which is more
       // accurate than the duration coded in the original media header.
-	  media_info_->set_media_duration_seconds(duration_seconds);
+      media_info_->set_media_duration_seconds(duration_seconds);
       mpd_notifier_->NotifyEndOfStream();
     }
     return;

--- a/packager/mpd/base/mock_mpd_notifier.h
+++ b/packager/mpd/base/mock_mpd_notifier.h
@@ -45,6 +45,7 @@ class MockMpdNotifier : public MpdNotifier {
                     const std::vector<uint8_t>& new_pssh));
   MOCK_METHOD2(NotifyMediaInfoUpdate,
                bool(uint32_t container_id, const MediaInfo& media_info));
+  MOCK_METHOD0(NotifyEndOfStream, bool());
   MOCK_METHOD0(Flush, bool());
 };
 

--- a/packager/mpd/base/mpd_builder.cc
+++ b/packager/mpd/base/mpd_builder.cc
@@ -331,11 +331,10 @@ float MpdBuilder::GetStaticMpdDuration() {
 }
 
 void MpdBuilder::FinalizeDynamicMpd() {
-
-	if (mpd_options_.mpd_params.event_to_vod_on_end_of_stream) {
-		mpd_options_.dash_profile = DashProfile::kOnDemand;
-		mpd_options_.mpd_type = MpdType::kStatic;
-	}
+  if (mpd_options_.mpd_params.event_to_vod_on_end_of_stream) {
+    mpd_options_.dash_profile = DashProfile::kOnDemand;
+    mpd_options_.mpd_type = MpdType::kStatic;
+  }
 }
 
 bool MpdBuilder::GetEarliestTimestamp(double* timestamp_seconds) {

--- a/packager/mpd/base/mpd_builder.cc
+++ b/packager/mpd/base/mpd_builder.cc
@@ -330,6 +330,14 @@ float MpdBuilder::GetStaticMpdDuration() {
   return total_duration;
 }
 
+void MpdBuilder::FinalizeDynamicMpd() {
+
+	if (mpd_options_.mpd_params.event_to_vod_on_end_of_stream) {
+		mpd_options_.dash_profile = DashProfile::kOnDemand;
+		mpd_options_.mpd_type = MpdType::kStatic;
+	}
+}
+
 bool MpdBuilder::GetEarliestTimestamp(double* timestamp_seconds) {
   DCHECK(timestamp_seconds);
   DCHECK(!periods_.empty());

--- a/packager/mpd/base/mpd_builder.h
+++ b/packager/mpd/base/mpd_builder.h
@@ -54,6 +54,10 @@ class MpdBuilder {
   ///         return a new Period.
   virtual Period* GetOrCreatePeriod(double start_time_in_seconds);
 
+  /// Convert the stream from a dynamic Live/EVENT to a static VOD stream.
+  /// This is a no-op for VOD streams.
+  void FinalizeDynamicMpd();
+
   /// Writes the MPD to the given string.
   /// @param[out] output is an output string where the MPD gets written.
   /// @return true on success, false otherwise.

--- a/packager/mpd/base/mpd_builder_unittest.cc
+++ b/packager/mpd/base/mpd_builder_unittest.cc
@@ -280,33 +280,20 @@ TEST_F(LiveMpdBuilderTest, DynamicCheckMpdAttributes) {
 
 TEST_F(LiveMpdBuilderTest, DynamicConvertToVoDCheckMpdAttributes) {
   static const char kExpectedOutput[] =
-      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-      "<!--Generated with https://github.com/shaka-project/shaka-packager"
-      " version <tag>-<hash>-<test>-->\n"
-      "<MPD xmlns=\"urn:mpeg:dash:schema:mpd:2011\""
-      " xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""
-      " xsi:schemaLocation=\"urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd\""
-      " profiles=\"urn:mpeg:dash:profile:isoff-on-demand:2011\""
-      " minBufferTime=\"PT2S\""
-      " type=\"static\""
-      " publishTime=\"2016-01-11T15:10:24Z\""
-      " availabilityStartTime=\"2011-12-25T12:30:00\""
-      " minimumUpdatePeriod=\"PT2S\">\n"
-      "  <UTCTiming schemeIdUri=\"urn:mpeg:dash:utc:http-xsdate:2014\" "
-      "value=\"http://foo.bar/my_body_is_the_current_date_and_time\"/>\n"
-      "  <UTCTiming schemeIdUri=\"urn:mpeg:dash:utc:http-head:2014\" "
-      "value=\"http://foo.bar/check_me_for_the_date_header\"/>\n"
-      "</MPD>\n";
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+    "<!--Generated with https://github.com/shaka-project/shaka-packager"
+    " version <tag>-<hash>-<test>-->\n"
+    "<MPD xmlns=\"urn:mpeg:dash:schema:mpd:2011\""
+    " xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""
+    " xsi:schemaLocation=\"urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd\""
+    " profiles=\"urn:mpeg:dash:profile:isoff-on-demand:2011\""
+    " minBufferTime=\"PT2S\""
+    " type=\"static\" mediaPresentationDuration=\"PT0S\"/>\n";
 
   std::string mpd_doc;
   mutable_mpd_options()->mpd_type = MpdType::kDynamic;
   mutable_mpd_options()->mpd_params.minimum_update_period = 2;
   mutable_mpd_options()->mpd_params.event_to_vod_on_end_of_stream = true;
-  mutable_mpd_options()->mpd_params.utc_timings = {
-      {"urn:mpeg:dash:utc:http-xsdate:2014",
-       "http://foo.bar/my_body_is_the_current_date_and_time"},
-      {"urn:mpeg:dash:utc:http-head:2014",
-       "http://foo.bar/check_me_for_the_date_header"}};
 
   mpd_.FinalizeDynamicMpd();
   ASSERT_TRUE(mpd_.ToString(&mpd_doc));

--- a/packager/mpd/base/mpd_builder_unittest.cc
+++ b/packager/mpd/base/mpd_builder_unittest.cc
@@ -280,15 +280,15 @@ TEST_F(LiveMpdBuilderTest, DynamicCheckMpdAttributes) {
 
 TEST_F(LiveMpdBuilderTest, DynamicConvertToVoDCheckMpdAttributes) {
   static const char kExpectedOutput[] =
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-    "<!--Generated with https://github.com/shaka-project/shaka-packager"
-    " version <tag>-<hash>-<test>-->\n"
-    "<MPD xmlns=\"urn:mpeg:dash:schema:mpd:2011\""
-    " xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""
-    " xsi:schemaLocation=\"urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd\""
-    " profiles=\"urn:mpeg:dash:profile:isoff-on-demand:2011\""
-    " minBufferTime=\"PT2S\""
-    " type=\"static\" mediaPresentationDuration=\"PT0S\"/>\n";
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+      "<!--Generated with https://github.com/shaka-project/shaka-packager"
+      " version <tag>-<hash>-<test>-->\n"
+      "<MPD xmlns=\"urn:mpeg:dash:schema:mpd:2011\""
+      " xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""
+      " xsi:schemaLocation=\"urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd\""
+      " profiles=\"urn:mpeg:dash:profile:isoff-on-demand:2011\""
+      " minBufferTime=\"PT2S\""
+      " type=\"static\" mediaPresentationDuration=\"PT0S\"/>\n";
 
   std::string mpd_doc;
   mutable_mpd_options()->mpd_type = MpdType::kDynamic;

--- a/packager/mpd/base/mpd_builder_unittest.cc
+++ b/packager/mpd/base/mpd_builder_unittest.cc
@@ -278,6 +278,39 @@ TEST_F(LiveMpdBuilderTest, DynamicCheckMpdAttributes) {
   ASSERT_EQ(kExpectedOutput, mpd_doc);
 }
 
+TEST_F(LiveMpdBuilderTest, DynamicConvertToVoDCheckMpdAttributes) {
+  static const char kExpectedOutput[] =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+      "<!--Generated with https://github.com/shaka-project/shaka-packager"
+      " version <tag>-<hash>-<test>-->\n"
+      "<MPD xmlns=\"urn:mpeg:dash:schema:mpd:2011\""
+      " xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""
+      " xsi:schemaLocation=\"urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd\""
+      " profiles=\"urn:mpeg:dash:profile:isoff-on-demand:2011\""
+      " minBufferTime=\"PT2S\""
+      " type=\"static\""
+      " publishTime=\"2016-01-11T15:10:24Z\""
+      " availabilityStartTime=\"2011-12-25T12:30:00\""
+      " minimumUpdatePeriod=\"PT2S\">\n"
+      "  <UTCTiming schemeIdUri=\"urn:mpeg:dash:utc:http-xsdate:2014\" "
+      "value=\"http://foo.bar/my_body_is_the_current_date_and_time\"/>\n"
+      "  <UTCTiming schemeIdUri=\"urn:mpeg:dash:utc:http-head:2014\" "
+      "value=\"http://foo.bar/check_me_for_the_date_header\"/>\n"
+      "</MPD>\n";
+
+  std::string mpd_doc;
+  mutable_mpd_options()->mpd_type = MpdType::kDynamic;
+  mutable_mpd_options()->mpd_params.minimum_update_period = 2;
+  mutable_mpd_options()->mpd_params.event_to_vod_on_end_of_stream = true;
+  mutable_mpd_options()->mpd_params.utc_timings = {
+      {"urn:mpeg:dash:utc:http-xsdate:2014",
+       "http://foo.bar/my_body_is_the_current_date_and_time"},
+      {"urn:mpeg:dash:utc:http-head:2014",
+       "http://foo.bar/check_me_for_the_date_header"}};
+  ASSERT_TRUE(mpd_.ToString(&mpd_doc));
+  ASSERT_EQ(kExpectedOutput, mpd_doc);
+}
+
 TEST_F(LiveMpdBuilderTest, StaticCheckMpdAttributes) {
   static const char kExpectedOutput[] =
       "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"

--- a/packager/mpd/base/mpd_builder_unittest.cc
+++ b/packager/mpd/base/mpd_builder_unittest.cc
@@ -307,6 +307,8 @@ TEST_F(LiveMpdBuilderTest, DynamicConvertToVoDCheckMpdAttributes) {
        "http://foo.bar/my_body_is_the_current_date_and_time"},
       {"urn:mpeg:dash:utc:http-head:2014",
        "http://foo.bar/check_me_for_the_date_header"}};
+
+  mpd_.FinalizeDynamicMpd();
   ASSERT_TRUE(mpd_.ToString(&mpd_doc));
   ASSERT_EQ(kExpectedOutput, mpd_doc);
 }

--- a/packager/mpd/base/mpd_notifier.h
+++ b/packager/mpd/base/mpd_notifier.h
@@ -143,6 +143,10 @@ class MpdNotifier {
   virtual bool NotifyMediaInfoUpdate(uint32_t container_id,
                                      const MediaInfo& media_info) = 0;
 
+  /// Convert the stream from a dynamic Live/EVENT to a static VOD stream.
+  /// This is a no-op for VOD streams.
+  virtual bool NotifyEndOfStream() = 0;
+
   /// Call this method to force a flush. Implementations might not write out
   /// the MPD to a stream (file, stdout, etc.) when the MPD is updated, this
   /// forces a flush.
@@ -156,6 +160,8 @@ class MpdNotifier {
 
   /// @return The mpd type for this object.
   MpdType mpd_type() const { return mpd_options_.mpd_type; }
+
+  void set_duration(float duration);
 
   /// @return The value of dash_force_segment_list flag
   bool use_segment_list() const {

--- a/packager/mpd/base/simple_mpd_notifier.cc
+++ b/packager/mpd/base/simple_mpd_notifier.cc
@@ -202,6 +202,12 @@ bool SimpleMpdNotifier::NotifyEncryptionUpdate(
   return true;
 }
 
+bool SimpleMpdNotifier::NotifyEndOfStream() {
+  absl::MutexLock lock(&lock_);
+  mpd_builder_->FinalizeDynamicMpd();
+  return true;
+}
+
 bool SimpleMpdNotifier::NotifyMediaInfoUpdate(uint32_t container_id,
                                               const MediaInfo& media_info) {
   absl::MutexLock lock(&lock_);

--- a/packager/mpd/base/simple_mpd_notifier.h
+++ b/packager/mpd/base/simple_mpd_notifier.h
@@ -57,6 +57,9 @@ class SimpleMpdNotifier : public MpdNotifier {
                               const std::vector<uint8_t>& new_pssh) override;
   bool NotifyMediaInfoUpdate(uint32_t container_id,
                              const MediaInfo& media_info) override;
+
+  bool NotifyEndOfStream() override;
+
   bool Flush() override;
   /// @}
 


### PR DESCRIPTION
Implement the MPEG DASH/HLS specifications to switch event/live streams to VOD when the streams end.  Use --event_to_vod_on_end_of_stream.

This change implements the DASH standard by:

1. Change MPD@type to static
2. Set MPD@mediaPresentationDuration to the media duration
3. Removing dynamic specific attributes in element, e.g. availabilityStartTime, minimumUpdatePeriod, timeShiftBufferDepth etc.
4. Set SegmentTemplate@presentationTimeOffset in Representations

This change implements the HLS standard by:

1. Switch the PLAYLIST-TYPE to VOD at the conclusion of a LIVE stream
2. Append an EXT-X-ENDLIST tag at the end of the stream

Fixes #321