### PR TITLE
fix: correct WebM color range value mapping for vpcC and colr boxes

### DIFF
--- a/packager/media/formats/webm/webm_video_client.cc
+++ b/packager/media/formats/webm/webm_video_client.cc
@@ -160,11 +160,7 @@ VPCodecConfigurationRecord WebMVideoClient::GetVpCodecConfig(
     vp_config.SetChromaLocation(chroma_siting_horz_, chroma_siting_vert_);
   }
   if (color_range_ != -1) {
-    if (color_range_ == 0)
-      vp_config.set_video_full_range_flag(false);
-    else if (color_range_ == 1)
-      vp_config.set_video_full_range_flag(true);
-    // Ignore for other values.
+    vp_config.set_video_full_range_flag(color_range_ == 2);
   }
   if (transfer_characteristics_ != -1) {
     vp_config.set_transfer_characteristics(transfer_characteristics_);
@@ -307,10 +303,10 @@ std::vector<uint8_t> WebMVideoClient::GenerateColrBoxData() const {
   writer.AppendInt(transfer);
   writer.AppendInt(matrix);
 
-  // WebM color_range: 0 = limited range, 1 = full range
+  // WebM color_range: 0=unspecified, 1=broadcast/limited, 2=full range.
   uint8_t full_range_flag = 0;
   if (color_range_ != -1) {
-    full_range_flag = (color_range_ == 1) ? 1 : 0;
+    full_range_flag = (color_range_ == 2) ? 1 : 0;
   }
   writer.AppendInt(full_range_flag);
 

--- a/packager/media/formats/webm/webm_video_client_unittest.cc
+++ b/packager/media/formats/webm/webm_video_client_unittest.cc
@@ -126,12 +126,20 @@ TEST_F(WebMVideoClientTest, GenerateColrBoxData_LimitedColorRange) {
   EXPECT_EQ(0x00, colr_data[18]);
 }
 
-TEST_F(WebMVideoClientTest, GenerateColrBoxData_FullColorRange) {
-  SetColorRange(1);  // 1 = full range in WebM
+TEST_F(WebMVideoClientTest, GenerateColrBoxData_BroadcastColorRange) {
+  SetColorRange(1);  // broadcast/limited
 
   std::vector<uint8_t> colr_data = client_.GenerateColrBoxData();
 
-  // Check full_range_flag is 1 (full range)
+  ASSERT_EQ(19u, colr_data.size());
+  EXPECT_EQ(0x00, colr_data[18]);
+}
+
+TEST_F(WebMVideoClientTest, GenerateColrBoxData_FullColorRange) {
+  SetColorRange(2);  // full range
+
+  std::vector<uint8_t> colr_data = client_.GenerateColrBoxData();
+
   ASSERT_EQ(19u, colr_data.size());
   EXPECT_EQ(0x01, colr_data[18]);
 }
@@ -204,7 +212,7 @@ TEST_F(WebMVideoClientTest, GetVideoStreamInfo_VP8WithColorInfo) {
   SetPixelDimensions(1280, 720);
 
   // Set color information
-  SetColorRange(1);  // Full range
+  SetColorRange(1);  // broadcast/limited range
 
   std::vector<uint8_t> codec_private;
   auto video_info = client_.GetVideoStreamInfo(1,        // track_num
@@ -220,9 +228,8 @@ TEST_F(WebMVideoClientTest, GetVideoStreamInfo_VP8WithColorInfo) {
   const std::vector<uint8_t>& colr_data = video_info->colr_data();
   EXPECT_FALSE(colr_data.empty());
 
-  // Verify full_range_flag is 1 (full range)
   ASSERT_EQ(19u, colr_data.size());
-  EXPECT_EQ(0x01, colr_data[18]);
+  EXPECT_EQ(0x00, colr_data[18]);
 }
 
 TEST_F(WebMVideoClientTest, GetVideoStreamInfo_VP9NoColorInfo) {
@@ -278,21 +285,22 @@ TEST_F(WebMVideoClientTest, GetVideoStreamInfo_AV1WithColorInfo) {
 TEST_F(WebMVideoClientTest, GetVpCodecConfig_ColorRange) {
   std::vector<uint8_t> codec_private;
 
-  // Test limited range
-  SetColorRange(0);
+  SetColorRange(0);  // unspecified
   VPCodecConfigurationRecord config = client_.GetVpCodecConfig(codec_private);
   EXPECT_FALSE(config.video_full_range_flag());
 
-  // Reset and test full range
   Reset();
-  SetColorRange(1);
+  SetColorRange(1);  // broadcast/limited
+  config = client_.GetVpCodecConfig(codec_private);
+  EXPECT_FALSE(config.video_full_range_flag());
+
+  Reset();
+  SetColorRange(2);  // full range
   config = client_.GetVpCodecConfig(codec_private);
   EXPECT_TRUE(config.video_full_range_flag());
 
-  // Reset and test unset (should not affect the config)
   Reset();
   config = client_.GetVpCodecConfig(codec_private);
-  // Default value in VPCodecConfigurationRecord
   EXPECT_FALSE(config.video_full_range_flag());
 }
 
@@ -302,7 +310,7 @@ TEST_F(WebMVideoClientTest, GetVpCodecConfig_AllColorParameters) {
   SetColorPrimaries(9);            // BT.2020
   SetTransferCharacteristics(16);  // ST 2084 (PQ)
   SetMatrixCoefficients(9);        // BT.2020
-  SetColorRange(1);                // Full range
+  SetColorRange(2);                // full range
 
   VPCodecConfigurationRecord config = client_.GetVpCodecConfig(codec_private);
 


### PR DESCRIPTION
Per the Matroska specification, Color.Range 1 means broadcast/limited (not full), and 2 means full range. The previous mapping treated value 1 as full range, causing incorrect video_full_range_flag in both the vpcC and colr boxes.

https://www.matroska.org/technical/elements.html\#:\~:text\=Clipping%20of%20the%20color%20ranges.%0A0%20%2D%20unspecified%2C%0A1%20%2D%20broadcast%20range%2C%0A2%20%2D%20full%20range%20\(no%20clipping\)%2C%0A3%20%2D%20defined%20by%20MatrixCoefficients%20/%20TransferCharacteristics