### PR TITLE
ci: Make linting happen entirely in parallel

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -44,6 +44,9 @@ jobs:
 
           python3 -m pip install --upgrade pylint==3.3.3
 
+          # Debug clang-format version for clarity.
+          clang-format --version
+
           # NOTE: Must use base.sha instead of base.ref, since we don't have
           # access to the branch name that base.ref would give us.
           # NOTE: Must also use fetch-depth: 2 in actions/checkout to have

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -41,7 +41,7 @@ jobs:
       ref: ${{ inputs.ref || github.ref }}
 
   build_and_test:
-    needs: [lint, settings]
+    needs: [settings]
     name: Build and test
     uses: ./.github/workflows/build.yaml
     with:
@@ -50,7 +50,7 @@ jobs:
       debug: ${{ needs.settings.outputs.debug != '' }}
 
   build_docs:
-    needs: [lint, settings]
+    needs: [settings]
     name: Build docs
     uses: ./.github/workflows/build-docs.yaml
     with:
@@ -58,16 +58,12 @@ jobs:
       debug: ${{ needs.settings.outputs.debug != '' }}
 
   official_docker_image:
-    needs: lint
     name: Official Docker image
     uses: ./.github/workflows/build-docker.yaml
     with:
       ref: ${{ inputs.ref || github.ref }}
 
   test_supported_linux_distros:
-    # Doesn't really "need" it, but let's not waste time on a series of docker
-    # builds just to cancel it because of a linter error.
-    needs: lint
     name: Test Linux distros
     uses: ./.github/workflows/test-linux-distros.yaml
     with:


### PR DESCRIPTION
It has been very, very annoying lately to have PRs get stuck in several loops of linter failures without finding out if the thing builds or passes tests.  From now on, lint in parallel with everything else.