### PR TITLE
style: Standardize the linter version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,20 @@ of your first [pull request][].
 [CONTRIBUTORS]: CONTRIBUTORS
 
 
+## Code style ##
+
+C++ code is formatted with `clang-format`. The project standardizes on
+clang-format 18; versions 18 through 22 are known to produce identical output
+as of the date this message was written and are all acceptable. Older versions
+(e.g. 14, 16) produce different output in some cases and should not be used.
+
+See `packager/tools/git/check_formatting.py` for installation instructions.
+You can install it as a pre-commit hook so formatting is checked automatically
+before each commit:
+
+    cp packager/tools/git/check_formatting.py .git/hooks/pre-commit
+
+
 ## Submitting a patch ##
 
   1. It's generally best to start by opening a new issue describing the bug or

--- a/packager/tools/git/check_formatting.py
+++ b/packager/tools/git/check_formatting.py
@@ -13,22 +13,36 @@ Install as pre-commit hook:
 
 Steps to install clang-format on your system if you don't have it already:
 
-1. Install the standalone clang-format tool:
+The project standardizes on clang-format 18. Versions 18 through 22 are known
+to produce identical output and are all acceptable. Older versions (e.g. 14,
+16) produce different output in some cases and should not be used.
 
-    Linux: sudo apt-get install clang-format
-    Mac:   brew install clang-format
+Ubuntu 24.04:
+    clang-format 18 is already installed. No action needed.
 
-2. Download git-clang-format from
+Ubuntu 22.04:
+    wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | \
+        sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+    echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main" | \
+        sudo tee /etc/apt/sources.list.d/llvm-18.list
+    sudo apt-get update && sudo apt-get install clang-format-18
+    sudo update-alternatives --install /usr/bin/clang-format clang-format \
+        /usr/bin/clang-format-18 18
+
+Mac:
+    brew install clang-format
+
+1. Download git-clang-format from
    https://github.com/llvm-mirror/clang/blob/master/tools/clang-format/git-clang-format
 
-3. Move the script somewhere in your path, e.g.
+2. Move the script somewhere in your path, e.g.
    sudo mv git-clang-format /usr/bin/
 
-4. Make the script executable: sudo chmod +x /usr/bin/git-clang-format.
+3. Make the script executable: sudo chmod +x /usr/bin/git-clang-format.
 
-5. Check it's been picked up by git: git clang-format -h.
+4. Check it's been picked up by git: git clang-format -h.
 
-6. Try it out with: git clang-format --diff.
+5. Try it out with: git clang-format --diff.
 
 """
 
@@ -37,23 +51,26 @@ import sys
 
 if __name__ == '__main__':
   is_pre_commit_hook = len(sys.argv) == 1
-  if not is_pre_commit_hook:
-    output = subprocess.check_output(['git', 'log', '--pretty=full', '-1'])
-    if b'disable-clang-format' in output:
-      sys.exit(0)
 
   command = ['git', 'clang-format', '--style', 'Chromium']
+
+  if is_pre_commit_hook:
+    # As a pre-commit, just run the command and fail if it fails.
+    subprocess.check_call(command)
+    sys.exit(0)
+
+  # Otherwise, get the diff and fail if it's not empty.
   command += sys.argv[1:]
   output = subprocess.check_output(command + ['--diff'])
 
-  if output not in [
+  if output in [
       b'no modified files to format\n',
       b'clang-format did not modify any files\n'
   ]:
-    print(output.decode('utf-8'))
-    print()
-    print('Code style is not correct. Please run {}.'.format(' '.join(command)))
-    print()
-    sys.exit(1)
-  else:
     sys.exit(0)
+
+  print(output.decode('utf-8'))
+  print()
+  print('Code style is not correct. Please run {}.'.format(' '.join(command)))
+  print()
+  sys.exit(1)


### PR DESCRIPTION
Also fix check_formatting.py to work as a pre-commit hook again.