### PR TITLE
ci: Pin clang-format-18 in linter workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -42,6 +42,20 @@ jobs:
           sudo install -m 755 git-clang-format /usr/local/bin/git-clang-format
           rm git-clang-format
 
+          # Somehow, GitHub's pre-installed clang-format 18 is untrustworthy
+          # and responds differently than upstream clang-format 18.  So install
+          # the upstream version now, explicitly.
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+              | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc >/dev/null
+          echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main" \
+              | sudo tee /etc/apt/sources.list.d/llvm-18.list >/dev/null
+          sudo apt-get update
+          sudo apt-get install clang-format-18
+          sudo update-alternatives --install /usr/bin/clang-format \
+              clang-format /usr/bin/clang-format-18 18
+          sudo update-alternatives --set clang-format \
+              /usr/bin/clang-format-18
+
           python3 -m pip install --upgrade pylint==3.3.3
 
           # Debug clang-format version for clarity.
@@ -52,7 +66,6 @@ jobs:
           # NOTE: Must also use fetch-depth: 2 in actions/checkout to have
           # access to the base ref for comparison.
           packager/tools/git/check_formatting.py \
-              --binary /usr/bin/clang-format \
               ${{ github.event.pull_request.base.sha || 'HEAD^' }}
 
           packager/tools/git/check_pylint.py

--- a/packager/tools/git/check_formatting.py
+++ b/packager/tools/git/check_formatting.py
@@ -33,7 +33,7 @@ Mac:
     brew install clang-format
 
 1. Download git-clang-format from
-   https://github.com/llvm-mirror/clang/blob/master/tools/clang-format/git-clang-format
+   https://raw.githubusercontent.com/llvm-mirror/clang/master/tools/clang-format/git-clang-format
 
 2. Move the script somewhere in your path, e.g.
    sudo mv git-clang-format /usr/bin/
@@ -52,7 +52,7 @@ import sys
 if __name__ == '__main__':
   is_pre_commit_hook = len(sys.argv) == 1
 
-  command = ['git', 'clang-format', '--style', 'Chromium']
+  command = ['git', 'clang-format']
 
   if is_pre_commit_hook:
     # As a pre-commit, just run the command and fail if it fails.
@@ -63,10 +63,11 @@ if __name__ == '__main__':
   command += sys.argv[1:]
   output = subprocess.check_output(command + ['--diff'])
 
-  if output in [
-      b'no modified files to format\n',
-      b'clang-format did not modify any files\n'
-  ]:
+  SUCCESS_MESSAGES = [
+    b'no modified files to format\n',
+    b'clang-format did not modify any files\n',
+  ]
+  if output in SUCCESS_MESSAGES:
     sys.exit(0)
 
   print(output.decode('utf-8'))


### PR DESCRIPTION
Also drop the explicit --style argument, letting .clang-format rule