### PR TITLE
feat(cmake): allow using system dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,10 @@ option(BUILD_SHARED_LIBS "Build libpackager as a shared library" OFF)
 # against mimalloc to replace the standard allocator in musl, which is slow.
 option(FULLY_STATIC "Attempt fully static linking of all CLI apps" OFF)
 
+# Whether to look for third-party dependencies on the system through
+# `find_package` instead of building them from git submodules.
+option(USE_SYSTEM_DEPENDENCIES "Search for dependencies on the system" OFF)
+
 # Enable CMake's test infrastructure.
 enable_testing()
 

--- a/packager/CMakeLists.txt
+++ b/packager/CMakeLists.txt
@@ -73,6 +73,47 @@ if(NOT Python3_EXECUTABLE)
   find_package(Python3 COMPONENTS Interpreter REQUIRED)
 endif()
 
+if(USE_SYSTEM_DEPENDENCIES)
+  # find_package results cannot be propagated to parent directories, so we have to
+  # define them here and not in the third_party subdirectory.
+  find_package(absl REQUIRED)
+  find_package(MbedTLS REQUIRED)
+  find_package(GTest REQUIRED)
+  find_package(CURL REQUIRED)
+  find_package(LibXml2 REQUIRED)
+  find_package(PNG REQUIRED)
+  find_package(nlohmann_json REQUIRED)
+  find_package(Protobuf CONFIG REQUIRED)
+  find_package(webm REQUIRED)
+
+  # Alias to same names as vendored dependencies
+  add_library(mbedtls ALIAS MbedTLS::mbedtls)
+  add_library(gmock ALIAS GTest::gmock)
+  add_library(gtest ALIAS GTest::gtest)
+  add_library(gtest_main ALIAS GTest::gtest_main)
+  add_library(libcurl ALIAS CURL::libcurl)
+  add_library(LibXml2 ALIAS LibXml2::LibXml2)
+  add_library(png_static ALIAS PNG::PNG) # not static but the expected library name
+  add_library(libprotobuf ALIAS protobuf::libprotobuf)
+  add_executable(protoc ALIAS protobuf::protoc)
+  add_library(webm ALIAS webm::webm)
+
+  # Verify that the Python protobuf module is installed
+  find_package(Python3 REQUIRED COMPONENTS Interpreter)
+  execute_process(
+      COMMAND "${Python3_EXECUTABLE}" -c "import google.protobuf"
+      RESULT_VARIABLE PYTHON_PROTOBUF_STATUS
+      OUTPUT_QUIET
+  )
+  if(NOT PYTHON_PROTOBUF_STATUS EQUAL 0)
+    message(FATAL_ERROR "Python module google.protobuf is unavailable")
+  endif()
+  # Dummy target for tools/pssh
+  add_custom_target(protobuf_py)
+else()
+  add_subdirectory(third_party)
+endif()
+
 # Subdirectories with their own CMakeLists.txt, all of whose targets are built.
 add_subdirectory(file)
 add_subdirectory(kv_pairs)
@@ -80,7 +121,6 @@ add_subdirectory(media)
 add_subdirectory(hls)
 add_subdirectory(mpd)
 add_subdirectory(status)
-add_subdirectory(third_party)
 add_subdirectory(tools)
 add_subdirectory(utils)
 add_subdirectory(version)

--- a/packager/tools/pssh/CMakeLists.txt
+++ b/packager/tools/pssh/CMakeLists.txt
@@ -12,6 +12,14 @@ set(PSSH_BOX_OUTPUTS
     ${CMAKE_BINARY_DIR}/packager/pssh-box-protos/widevine_common_encryption_pb2.py
     ${CMAKE_BINARY_DIR}/packager/pssh-box-protos/widevine_pssh_data_pb2.py)
 
+if(NOT USE_SYSTEM_DEPENDENCIES)
+  set(PROTO_COPY_EXTRAS
+      COMMAND
+          ${CMAKE_COMMAND} -E copy_directory
+          ${CMAKE_BINARY_DIR}/packager/third_party/protobuf/py/google
+          ${CMAKE_BINARY_DIR}/packager/pssh-box-protos/google)
+endif()
+
 add_custom_command(
     DEPENDS
         protobuf_py
@@ -27,13 +35,10 @@ add_custom_command(
         ${CMAKE_BINARY_DIR}/packager/media/base/widevine_pssh_data_pb2.py
         ${CMAKE_BINARY_DIR}/packager/pssh-box-protos/
     COMMAND
-        ${CMAKE_COMMAND} -E copy_directory
-        ${CMAKE_BINARY_DIR}/packager/third_party/protobuf/py/google
-        ${CMAKE_BINARY_DIR}/packager/pssh-box-protos/google
-    COMMAND
         ${CMAKE_COMMAND} -E copy
         ${CMAKE_CURRENT_SOURCE_DIR}/pssh-box.py
-        ${CMAKE_BINARY_DIR}/packager/)
+        ${CMAKE_BINARY_DIR}/packager
+    ${PROTO_COPY_EXTRAS})
 
 add_custom_target(pssh_box_py ALL DEPENDS ${PSSH_BOX_OUTPUTS})
 


### PR DESCRIPTION
Another of our currently vendored patches for nixpkgs / NixOS that has been in use for about two years, hidden behind an option to allow both variants to coexist.
This might need some more back and forth discussion to get into an acceptable state for upstream.
The idea is that opting into `USE_SYSTEM_DEPENDENCIES` works without any submodules, so when this option is enabled, we also expect the system to already have Python with the `google.protobuf` module ready and available.

