### PR TITLE
fix: Ignore already-deleted files when removing old segments

### DIFF
--- a/packager/file/file.cc
+++ b/packager/file/file.cc
@@ -142,8 +142,7 @@ File* CreateMemoryFile(const char* file_name, const char* mode) {
 }
 
 bool DeleteMemoryFile(const char* file_name) {
-  MemoryFile::Delete(file_name);
-  return true;
+  return MemoryFile::Delete(file_name);
 }
 
 static const FileTypeInfo kFileTypeInfo[] = {

--- a/packager/file/memory_file.cc
+++ b/packager/file/memory_file.cc
@@ -31,17 +31,17 @@ class FileSystem {
     return &instance;
   }
 
-  void Delete(const std::string& file_name) {
+  bool Delete(const std::string& file_name) {
     absl::MutexLock auto_lock(mutex_);
 
     if (open_files_.find(file_name) != open_files_.end()) {
       LOG(ERROR) << "File '" << file_name
                  << "' is still open. Deleting an open MemoryFile is not "
                     "allowed. Exit without deleting the file.";
-      return;
+      return false;
     }
 
-    files_.erase(file_name);
+    return files_.erase(file_name) > 0;
   }
 
   void DeleteAll() {
@@ -191,8 +191,8 @@ void MemoryFile::DeleteAll() {
   FileSystem::Instance()->DeleteAll();
 }
 
-void MemoryFile::Delete(const std::string& file_name) {
-  FileSystem::Instance()->Delete(file_name);
+bool MemoryFile::Delete(const std::string& file_name) {
+  return FileSystem::Instance()->Delete(file_name);
 }
 
 }  // namespace shaka

--- a/packager/file/memory_file.h
+++ b/packager/file/memory_file.h
@@ -40,7 +40,7 @@ class MemoryFile : public File {
   static void DeleteAll();
   /// Deletes the memory file data with the given file_name.  Any objects open
   /// with that file name will be in an undefined state.
-  static void Delete(const std::string& file_name);
+  static bool Delete(const std::string& file_name);
 
  protected:
   ~MemoryFile() override;

--- a/packager/hls/base/media_playlist.cc
+++ b/packager/hls/base/media_playlist.cc
@@ -830,8 +830,7 @@ void MediaPlaylist::RemoveOldSegment(int64_t start_time) {
     // returns >= 0 if the file exists, and < 0 if it does not.
     if (!File::Delete(file_name.c_str()) &&
         File::GetFileSize(file_name.c_str()) >= 0) {
-      LOG(WARNING) << "Failed to delete " << file_name
-                   << "; Will retry later.";
+      LOG(WARNING) << "Failed to delete " << file_name << "; Will retry later.";
       break;
     }
     segments_to_be_removed_.pop_front();

--- a/packager/hls/base/media_playlist.cc
+++ b/packager/hls/base/media_playlist.cc
@@ -821,9 +821,16 @@ void MediaPlaylist::RemoveOldSegment(int64_t start_time) {
       media_info_.bandwidth()));
   while (segments_to_be_removed_.size() >
          hls_params_.preserved_segments_outside_live_window) {
-    VLOG(2) << "Deleting " << segments_to_be_removed_.front();
-    if (!File::Delete(segments_to_be_removed_.front().c_str())) {
-      LOG(WARNING) << "Failed to delete " << segments_to_be_removed_.front()
+    const std::string& file_name = segments_to_be_removed_.front();
+    VLOG(2) << "Deleting " << file_name;
+    // DASH and HLS outputs could both be tracking the same files and are in a
+    // race to delete them. Delete() returns false if the file does not exist,
+    // but we only want to retry if the file does exist (indicating a failure
+    // to delete, rather than the file already being gone). GetFileSize()
+    // returns >= 0 if the file exists, and < 0 if it does not.
+    if (!File::Delete(file_name.c_str()) &&
+        File::GetFileSize(file_name.c_str()) >= 0) {
+      LOG(WARNING) << "Failed to delete " << file_name
                    << "; Will retry later.";
       break;
     }

--- a/packager/hls/base/media_playlist_unittest.cc
+++ b/packager/hls/base/media_playlist_unittest.cc
@@ -1200,6 +1200,30 @@ TEST_P(MediaPlaylistDeleteSegmentsTest, ManySegments) {
   EXPECT_TRUE(SegmentDeleted(GetSegmentName(last_available_segment_index - 1)));
 }
 
+// Verify that if a segment is already deleted (e.g. by a racing DASH packager),
+// the deletion of subsequent segments is not blocked.
+TEST_P(MediaPlaylistDeleteSegmentsTest, FileAlreadyDeleted) {
+  for (int i = 0; i < kMaxNumSegmentsAvailable; ++i) {
+    media_playlist_->AddSegment(kIgnoredSegmentName, GetTime(i), kDuration,
+                                kZeroByteOffset, kMBytes);
+  }
+
+  // Manually delete the first segment to simulate a race condition.
+  File::Delete(GetSegmentName(0).c_str());
+
+  // Add more segments to trigger the deletion of the first two segments.
+  media_playlist_->AddSegment(kIgnoredSegmentName,
+                              GetTime(kMaxNumSegmentsAvailable), kDuration,
+                              kZeroByteOffset, kMBytes);
+  media_playlist_->AddSegment(kIgnoredSegmentName,
+                              GetTime(kMaxNumSegmentsAvailable + 1), kDuration,
+                              kZeroByteOffset, kMBytes);
+
+  // The second segment should still be deleted successfully, even though the
+  // first segment was already deleted before the packager tried to delete it.
+  EXPECT_TRUE(SegmentDeleted(GetSegmentName(1)));
+}
+
 INSTANTIATE_TEST_CASE_P(
     TimeOrNumber,
     MediaPlaylistDeleteSegmentsTest,

--- a/packager/mpd/base/representation.cc
+++ b/packager/mpd/base/representation.cc
@@ -541,8 +541,7 @@ void Representation::RemoveOldSegment(SegmentInfo* segment_info) {
     // returns >= 0 if the file exists, and < 0 if it does not.
     if (!File::Delete(file_name.c_str()) &&
         File::GetFileSize(file_name.c_str()) >= 0) {
-      LOG(WARNING) << "Failed to delete " << file_name
-                   << "; Will retry later.";
+      LOG(WARNING) << "Failed to delete " << file_name << "; Will retry later.";
       break;
     }
     segments_to_be_removed_.pop_front();

--- a/packager/mpd/base/representation.cc
+++ b/packager/mpd/base/representation.cc
@@ -532,9 +532,16 @@ void Representation::RemoveOldSegment(SegmentInfo* segment_info) {
                             start_number, media_info_.bandwidth()));
   while (segments_to_be_removed_.size() >
          mpd_options_.mpd_params.preserved_segments_outside_live_window) {
-    VLOG(2) << "Deleting " << segments_to_be_removed_.front();
-    if (!File::Delete(segments_to_be_removed_.front().c_str())) {
-      LOG(WARNING) << "Failed to delete " << segments_to_be_removed_.front()
+    const std::string& file_name = segments_to_be_removed_.front();
+    VLOG(2) << "Deleting " << file_name;
+    // DASH and HLS outputs could both be tracking the same files and are in a
+    // race to delete them. Delete() returns false if the file does not exist,
+    // but we only want to retry if the file does exist (indicating a failure
+    // to delete, rather than the file already being gone). GetFileSize()
+    // returns >= 0 if the file exists, and < 0 if it does not.
+    if (!File::Delete(file_name.c_str()) &&
+        File::GetFileSize(file_name.c_str()) >= 0) {
+      LOG(WARNING) << "Failed to delete " << file_name
                    << "; Will retry later.";
       break;
     }

--- a/packager/mpd/base/representation_unittest.cc
+++ b/packager/mpd/base/representation_unittest.cc
@@ -1403,4 +1403,25 @@ TEST_F(RepresentationDeleteSegmentsTest, ManyRepeatingSegments) {
       absl::StrFormat(kStringPrintTemplate, last_available_segment_index - 1)));
 }
 
+// Verify that if a segment is already deleted (e.g. by a racing HLS packager),
+// the deletion of subsequent segments is not blocked.
+TEST_F(RepresentationDeleteSegmentsTest, FileAlreadyDeleted) {
+  for (int i = 0; i < kMaxNumSegmentsAvailable; ++i) {
+    AddSegments(kInitialStartTime + i * kDuration, kDuration, kSize, kNoRepeat);
+  }
+
+  // Manually delete the first segment to simulate a race condition.
+  File::Delete(absl::StrFormat(kStringPrintTemplate, 1).c_str());
+
+  // Add more segments to trigger the deletion of the first two segments.
+  AddSegments(kInitialStartTime + kMaxNumSegmentsAvailable * kDuration,
+              kDuration, kSize, kNoRepeat);
+  AddSegments(kInitialStartTime + (kMaxNumSegmentsAvailable + 1) * kDuration,
+              kDuration, kSize, kNoRepeat);
+
+  // The second segment should still be deleted successfully, even though the
+  // first segment was already deleted before the packager tried to delete it.
+  EXPECT_TRUE(SegmentDeleted(absl::StrFormat(kStringPrintTemplate, 2)));
+}
+
 }  // namespace shaka


### PR DESCRIPTION
When generating both DASH and HLS outputs, they could both be tracking the same files and racing to delete them as they fall out of the live window. If one output deletes a segment before the other tries to do so, File::Delete() returns false. We only want to retry if the file actually exists but failed to delete. We can use GetFileSize() to check if the file still exists (>= 0).

Also updated MemoryFile::Delete to return a boolean indicating whether the file existed and was deleted successfully so that we can accurately mock file deletion behaviors in unit tests.

Fixes #1367