### PR TITLE
docs: add Homebrew installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,22 @@ There are several ways you can get Shaka Packager.
 - Built from source, see
   [Build Instructions](https://github.com/shaka-project/shaka-packager/blob/main/docs/source/build_instructions.md)
   for details.
+- Install via [Homebrew](https://brew.sh/) on macOS/Linux, using the
+  [langtutheky/langtutheky](https://github.com/langtutheky/homebrew-langtutheky) tap
+  (formula originally authored by [@jhelgert](https://github.com/jhelgert)):
+```sh
+  brew tap langtutheky/langtutheky
+```
+
+  Then install the formula (builds from source):
+```sh
+  brew install shaka-packager
+```
+
+  Or install the cask (prebuilt binary, automatically selects x64 or arm64):
+```sh
+  brew install --cask shaka-packager
+```
 
 # Useful Links
 


### PR DESCRIPTION
## Summary

Adds Homebrew as an installation option under the "Getting Shaka Packager"
section of the README.

## Changes

- Added a new bullet to the "Getting Shaka Packager" section documenting
  installation via the `langtutheky/langtutheky` Homebrew tap
- Covers both the formula (builds from source) and cask (prebuilt binary)
- The cask automatically detects and applies the correct x64 or arm64 binary

## Tap

https://github.com/langtutheky/homebrew-langtutheky

Supports Shaka Packager v3.5.0–v3.7.1.

## Credit

The formula was originally authored by @jhelgert in
[homebrew-core#270697](https://github.com/Homebrew/homebrew-core/pull/270697).

## Testing

Verified on macOS with both:
- `brew install shaka-packager` (formula)
- `brew install --cask shaka-packager` (cask)