### PR TITLE
chore: Convert issue template to a form that sets the native issue type

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,3 +1,10 @@
+---
+name: Bug report
+about: Report a bug in Shaka Packager
+title: ''
+type: Bug
+---
+
 ## System info
 **Operating System**: <e.g. macOS Sierra, Ubuntu 14.04 trusty etc>
 **Shaka Packager Version**: <e.g. v1.6.1, commit SHA etc>


### PR DESCRIPTION
Move the single legacy .github/ISSUE_TEMPLATE.md to a folder-based template at .github/ISSUE_TEMPLATE/bug.md, which supports front matter, and set the native issue 'type' field to Bug.